### PR TITLE
Implement Drop for ZenWindow to ensure clean shutdown

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,7 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -37,9 +40,24 @@ where
     globals.bind::<P, _, _>(qh, 1..=1, ()).ok()
 }
 
+/// Poll the Wayland connection fd with a timeout.
+///
+/// Returns `true` if the fd is readable, `false` on timeout or error.
+fn poll_wayland_fd(fd: std::os::unix::io::BorrowedFd<'_>, timeout_ms: i32) -> bool {
+    use std::os::unix::io::AsRawFd;
+    let mut pollfd = libc::pollfd {
+        fd: fd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let ret = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+    ret > 0
+}
+
 pub(crate) fn run(
     config: ZenConfig,
     ready_tx: Option<mpsc::Sender<Result<(), String>>>,
+    shutdown: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(delay) = config.settle_delay {
         std::thread::sleep(delay);
@@ -250,19 +268,36 @@ pub(crate) fn run(
     // Steady state — toplevel Done handler starts cross-fade transitions
     let transition_tick = Duration::from_millis(8);
     while state.running {
+        if shutdown.load(Ordering::Acquire) {
+            state.running = false;
+            break;
+        }
+
         if state.is_transitioning() {
             state.tick_transition();
             event_queue.flush()?;
             event_queue.dispatch_pending(&mut state)?;
             std::thread::sleep(transition_tick);
         } else {
-            event_queue.blocking_dispatch(&mut state)?;
-            // Flush draws from event handlers (e.g. old monitor dim)
-            // blocking_dispatch flushes BEFORE dispatching, so anything
-            // enqueued during dispatch needs an explicit flush after.
+            // Poll-based dispatch: wait up to 100ms for events so we
+            // can periodically check the shutdown signal.
+            event_queue.flush()?;
+            if let Some(guard) = event_queue.prepare_read() {
+                let fd = guard.connection_fd();
+                if poll_wayland_fd(fd, 100) {
+                    if let Err(e) = guard.read() {
+                        state.running = false;
+                        return Err(e.into());
+                    }
+                }
+                // If poll timed out, guard is dropped which cancels the read.
+            }
+            event_queue.dispatch_pending(&mut state)?;
             event_queue.flush()?;
         }
     }
 
+    // Dropping state/surfaces/connection here cleans up Wayland
+    // resources: surfaces are destroyed and gamma ramps are restored.
     Ok(())
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -100,12 +103,14 @@ impl ZenWindowBuilder {
     /// and restores gamma.
     pub fn spawn(self) -> Result<ZenWindow, Box<dyn std::error::Error + Send + Sync>> {
         let (ready_tx, ready_rx) = mpsc::channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
 
         let handle = std::thread::Builder::new()
             .name("wl-zenwindow".into())
             .spawn({
                 let config = ZenConfig::from_builder(&self);
-                move || run(config, Some(ready_tx))
+                let shutdown = Arc::clone(&shutdown);
+                move || run(config, Some(ready_tx), shutdown)
             })?;
 
         match ready_rx.recv() {
@@ -116,6 +121,7 @@ impl ZenWindowBuilder {
 
         Ok(ZenWindow {
             _handle: Some(handle),
+            shutdown,
         })
     }
 
@@ -126,15 +132,21 @@ impl ZenWindowBuilder {
     ///
     /// Returns a [`ZenWindow`] handle. Dropping it removes overlays.
     pub fn spawn_nonblocking(self) -> ZenWindow {
+        let shutdown = Arc::new(AtomicBool::new(false));
+
         let handle = std::thread::Builder::new()
             .name("wl-zenwindow".into())
             .spawn({
                 let config = ZenConfig::from_builder(&self);
-                move || run(config, None)
+                let shutdown = Arc::clone(&shutdown);
+                move || run(config, None, shutdown)
             })
             .ok();
 
-        ZenWindow { _handle: handle }
+        ZenWindow {
+            _handle: handle,
+            shutdown,
+        }
     }
 }
 
@@ -144,12 +156,33 @@ impl ZenWindowBuilder {
 /// Dropping it disconnects from Wayland, removes overlays, and restores gamma.
 pub struct ZenWindow {
     _handle: Option<JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>>,
+    shutdown: Arc<AtomicBool>,
 }
 
 impl ZenWindow {
     /// Create a new builder to configure which outputs to dim.
     pub fn builder() -> ZenWindowBuilder {
         ZenWindowBuilder::new()
+    }
+}
+
+impl Drop for ZenWindow {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(handle) = self._handle.take() {
+            // Give the event loop time to notice the shutdown signal and clean up.
+            // The poll timeout in the event loop is 100ms, so 1 second is generous.
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            while !handle.is_finished() {
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2

## Problem

`ZenWindow._handle` stored a `JoinHandle` but never joined it and had no `Drop` implementation. The `running` field on `ZenState` existed but nothing ever set it to `false`. When `ZenWindow` was dropped, the thread silently detached — overlay surfaces could linger, gamma ramps wouldn't be restored, and the background thread would leak.

## Changes

### Shared shutdown signal (`Arc<AtomicBool>`)
- Added to `ZenWindow` struct and passed through to the `run()` function
- Both `spawn()` and `spawn_nonblocking()` create and share the signal

### `Drop` for `ZenWindow`
- Sets the shutdown signal (`Release` ordering)
- Waits up to 1 second for the thread to finish, polling every 10ms
- Joins the thread if it finishes within the deadline

### Poll-based event loop
- Replaced `blocking_dispatch` with `prepare_read()` + `poll()` (100ms timeout) + `dispatch_pending()`
- The event loop checks the shutdown signal each iteration
- When shutdown is signaled, sets `running = false` and breaks out of the loop
- Dropping the Wayland connection/state naturally cleans up surfaces and restores gamma