### PR TITLE
Replace Box<dyn Error> with structured SpawnError enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6799,6 +6799,7 @@ dependencies = [
  "gpui",
  "libc",
  "smithay-client-toolkit",
+ "thiserror 2.0.18",
  "wayland-client",
  "wayland-protocols 0.32.11",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["os::linux-apis", "gui"]
 [dependencies]
 libc = "0.2"
 smithay-client-toolkit = "0.20"
+thiserror = "2"
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["staging"] }
 wayland-protocols-wlr = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+/// Errors that can occur when spawning zen overlays.
+///
+/// Returned by [`ZenWindowBuilder::spawn`](crate::ZenWindowBuilder::spawn).
+/// Callers can match on variants to distinguish failure modes and decide
+/// whether to retry or fall back gracefully.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SpawnError {
+    /// No Wayland display could be reached.
+    ///
+    /// Usually means `$WAYLAND_DISPLAY` is unset or the compositor isn't
+    /// running.
+    #[error("failed to connect to Wayland display")]
+    WaylandConnection(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// A required Wayland protocol is not advertised by the compositor.
+    ///
+    /// `protocol` names the missing global (e.g. `"wl_compositor"`,
+    /// `"zwlr_layer_shell_v1"`, `"wl_shm"`).
+    #[error("required Wayland protocol unavailable: {protocol}")]
+    MissingProtocol {
+        protocol: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The OS refused to create a background thread.
+    #[error("failed to spawn background thread")]
+    ThreadSpawn(#[source] std::io::Error),
+
+    /// Wayland setup failed after connecting but before overlays were ready.
+    ///
+    /// Covers registry initialization, shared-memory pool creation, and
+    /// initial roundtrip failures.
+    #[error("Wayland setup failed")]
+    Setup(#[source] Box<dyn std::error::Error + Send + Sync>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!     .spawn_nonblocking();
 //! ```
 
+mod error;
 mod gamma;
 mod handlers;
 mod run;
@@ -45,5 +46,6 @@ mod toplevel;
 mod transition;
 mod window;
 
+pub use error::SpawnError;
 pub use window::ZenWindow;
 pub use window::ZenWindowBuilder;

--- a/src/run.rs
+++ b/src/run.rs
@@ -25,6 +25,7 @@ use wayland_protocols::wp::viewporter::client::wp_viewporter::WpViewporter;
 use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1;
 use wayland_protocols_wlr::gamma_control::v1::client::zwlr_gamma_control_manager_v1::ZwlrGammaControlManagerV1;
 
+use crate::error::SpawnError;
 use crate::state::OverlaySurface;
 use crate::state::ZenState;
 use crate::transition::ease_out_quad;
@@ -56,26 +57,37 @@ fn poll_wayland_fd(fd: std::os::unix::io::BorrowedFd<'_>, timeout_ms: i32) -> bo
 
 pub(crate) fn run(
     config: ZenConfig,
-    ready_tx: Option<mpsc::Sender<Result<(), String>>>,
+    ready_tx: Option<mpsc::Sender<()>>,
     shutdown: Arc<AtomicBool>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), SpawnError> {
     if let Some(delay) = config.settle_delay {
         std::thread::sleep(delay);
     }
 
-    let conn = Connection::connect_to_env()?;
-    let (globals, mut event_queue) = registry_queue_init(&conn)?;
+    let conn = Connection::connect_to_env().map_err(|e| SpawnError::WaylandConnection(e.into()))?;
+    let (globals, mut event_queue) =
+        registry_queue_init(&conn).map_err(|e| SpawnError::Setup(e.into()))?;
     let qh = event_queue.handle();
 
     let registry = RegistryState::new(&globals);
     let output_state = OutputState::new(&globals, &qh);
-    let compositor = CompositorState::bind(&globals, &qh)?;
-    let layer_shell = LayerShell::bind(&globals, &qh)?;
+    let compositor =
+        CompositorState::bind(&globals, &qh).map_err(|e| SpawnError::MissingProtocol {
+            protocol: "wl_compositor",
+            source: e.into(),
+        })?;
+    let layer_shell = LayerShell::bind(&globals, &qh).map_err(|e| SpawnError::MissingProtocol {
+        protocol: "zwlr_layer_shell_v1",
+        source: e.into(),
+    })?;
     let viewporter: Option<WpViewporter> = try_bind(&globals, &qh);
     let alpha_modifier: Option<WpAlphaModifierV1> = try_bind(&globals, &qh);
     let gamma_manager: Option<ZwlrGammaControlManagerV1> = try_bind(&globals, &qh);
-    let shm = Shm::bind(&globals, &qh)?;
-    let pool = SlotPool::new(256, &shm)?;
+    let shm = Shm::bind(&globals, &qh).map_err(|e| SpawnError::MissingProtocol {
+        protocol: "wl_shm",
+        source: e.into(),
+    })?;
+    let pool = SlotPool::new(256, &shm).map_err(|e| SpawnError::Setup(e.into()))?;
 
     let toplevel_manager: Option<ZwlrForeignToplevelManagerV1> = if config.skip_active {
         try_bind(&globals, &qh)
@@ -111,8 +123,12 @@ pub(crate) fn run(
     };
 
     // Discover outputs and toplevels
-    event_queue.roundtrip(&mut state)?;
-    event_queue.roundtrip(&mut state)?;
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|e| SpawnError::Setup(e.into()))?;
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|e| SpawnError::Setup(e.into()))?;
 
     // Snapshot the active output
     state.active_output = state.active_output_name();
@@ -214,13 +230,17 @@ pub(crate) fn run(
         });
     }
 
-    event_queue.roundtrip(&mut state)?;
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|e| SpawnError::Setup(e.into()))?;
     while state.surfaces.iter().any(|s| !s.configured) {
-        event_queue.blocking_dispatch(&mut state)?;
+        event_queue
+            .blocking_dispatch(&mut state)
+            .map_err(|e| SpawnError::Setup(e.into()))?;
     }
 
     if let Some(tx) = ready_tx {
-        tx.send(Ok(())).ok();
+        tx.send(()).ok();
     }
 
     if let Some(duration) = config.fade_duration {
@@ -252,8 +272,12 @@ pub(crate) fn run(
                 state.set_gamma_dimmed(current_brightness);
             }
 
-            event_queue.flush()?;
-            event_queue.dispatch_pending(&mut state)?;
+            event_queue
+                .flush()
+                .map_err(|e| SpawnError::Setup(e.into()))?;
+            event_queue
+                .dispatch_pending(&mut state)
+                .map_err(|e| SpawnError::Setup(e.into()))?;
 
             if t >= 1.0 {
                 break;
@@ -275,25 +299,35 @@ pub(crate) fn run(
 
         if state.is_transitioning() {
             state.tick_transition();
-            event_queue.flush()?;
-            event_queue.dispatch_pending(&mut state)?;
+            event_queue
+                .flush()
+                .map_err(|e| SpawnError::Setup(e.into()))?;
+            event_queue
+                .dispatch_pending(&mut state)
+                .map_err(|e| SpawnError::Setup(e.into()))?;
             std::thread::sleep(transition_tick);
         } else {
             // Poll-based dispatch: wait up to 100ms for events so we
             // can periodically check the shutdown signal.
-            event_queue.flush()?;
+            event_queue
+                .flush()
+                .map_err(|e| SpawnError::Setup(e.into()))?;
             if let Some(guard) = event_queue.prepare_read() {
                 let fd = guard.connection_fd();
                 if poll_wayland_fd(fd, 100) {
                     if let Err(e) = guard.read() {
                         state.running = false;
-                        return Err(e.into());
+                        return Err(SpawnError::Setup(e.into()));
                     }
                 }
                 // If poll timed out, guard is dropped which cancels the read.
             }
-            event_queue.dispatch_pending(&mut state)?;
-            event_queue.flush()?;
+            event_queue
+                .dispatch_pending(&mut state)
+                .map_err(|e| SpawnError::Setup(e.into()))?;
+            event_queue
+                .flush()
+                .map_err(|e| SpawnError::Setup(e.into()))?;
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use crate::error::SpawnError;
 use crate::run::run;
 
 /// Builder for configuring which outputs to dim.
@@ -97,11 +98,13 @@ impl ZenWindowBuilder {
     /// Spawn on a background thread.
     ///
     /// Blocks briefly until Wayland setup completes (typically a few
-    /// milliseconds). Returns an error if the Wayland connection fails.
+    /// milliseconds). Returns a [`SpawnError`] if the Wayland connection
+    /// fails, a required protocol is missing, or the thread cannot be
+    /// created.
     ///
     /// Returns a [`ZenWindow`] handle. Dropping it removes overlays
     /// and restores gamma.
-    pub fn spawn(self) -> Result<ZenWindow, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn spawn(self) -> Result<ZenWindow, SpawnError> {
         let (ready_tx, ready_rx) = mpsc::channel();
         let shutdown = Arc::new(AtomicBool::new(false));
 
@@ -111,18 +114,27 @@ impl ZenWindowBuilder {
                 let config = ZenConfig::from_builder(&self);
                 let shutdown = Arc::clone(&shutdown);
                 move || run(config, Some(ready_tx), shutdown)
-            })?;
+            })
+            .map_err(SpawnError::ThreadSpawn)?;
 
         match ready_rx.recv() {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(e.into()),
-            Err(_) => {}
+            Ok(()) => Ok(ZenWindow {
+                _handle: Some(handle),
+                shutdown,
+            }),
+            Err(_) => {
+                // Channel closed without a ready signal — the thread
+                // returned an error or panicked during setup.
+                match handle.join() {
+                    Ok(Err(e)) => Err(e),
+                    Err(payload) => std::panic::resume_unwind(payload),
+                    Ok(Ok(())) => Ok(ZenWindow {
+                        _handle: None,
+                        shutdown,
+                    }),
+                }
+            }
         }
-
-        Ok(ZenWindow {
-            _handle: Some(handle),
-            shutdown,
-        })
     }
 
     /// Spawn without blocking the calling thread.
@@ -155,7 +167,7 @@ impl ZenWindowBuilder {
 /// Overlay surfaces remain visible as long as this handle exists.
 /// Dropping it disconnects from Wayland, removes overlays, and restores gamma.
 pub struct ZenWindow {
-    _handle: Option<JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>>,
+    _handle: Option<JoinHandle<Result<(), SpawnError>>>,
     shutdown: Arc<AtomicBool>,
 }
 


### PR DESCRIPTION
Closes #3

Replace the opaque `Box<dyn Error + Send + Sync>` return type from `spawn()` with a structured `SpawnError` enum so callers can match on failure modes and make recovery decisions.

## Changes

### New: `src/error.rs`

Defines `SpawnError` with four variants:

- **`WaylandConnection`** — no Wayland display reachable (`$WAYLAND_DISPLAY` unset or compositor not running)
- **`MissingProtocol { protocol, source }`** — a required global (`wl_compositor`, `zwlr_layer_shell_v1`, `wl_shm`) is not advertised by the compositor
- **`ThreadSpawn`** — the OS refused to create the background thread
- **`Setup`** — registry init, SHM pool creation, or initial roundtrip failure

The enum is `#[non_exhaustive]` for semver safety. Each variant preserves the error chain via `#[source]`.

### `src/run.rs`

- Simplified `ready_tx` channel from `Sender<Result<(), String>>` to `Sender<()>` — the `Result` wrapper was dead code (only `Ok(())` was ever sent)
- Changed return type to `Result<(), SpawnError>`
- Each `?` maps to the appropriate variant with `.map_err()`

### `src/window.rs`

- `spawn()` returns `Result<ZenWindow, SpawnError>`
- Thread spawn failure maps to `SpawnError::ThreadSpawn`
- When the ready channel disconnects (thread failed before setup completed), `handle.join()` now retrieves the actual `SpawnError` — previously this was silently swallowed
- Thread panics are re-raised via `std::panic::resume_unwind` (panics are bugs, not recoverable errors)