### PR TITLE
refactor: replace is_backdrop bool with SurfaceRole enum

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -98,7 +98,7 @@ impl LayerShellHandler for ZenState {
             self.surfaces[idx].height = configure.new_size.1;
             self.surfaces[idx].configured = true;
 
-            let alpha = if self.surfaces[idx].is_backdrop {
+            let alpha = if self.surfaces[idx].is_backdrop() {
                 // Backdrops are always fully opaque
                 (self.target_opacity * 255.0) as u8
             } else if self.fading || self.is_skipped(idx) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -26,6 +26,7 @@ use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_m
 use wayland_protocols_wlr::gamma_control::v1::client::zwlr_gamma_control_manager_v1::ZwlrGammaControlManagerV1;
 
 use crate::state::OverlaySurface;
+use crate::state::SurfaceRole;
 use crate::state::ZenState;
 use crate::transition::ease_out_quad;
 use crate::window::ZenConfig;
@@ -172,7 +173,7 @@ pub(crate) fn run(
 
         state.surfaces.push(OverlaySurface {
             output_name: output_name.clone(),
-            is_backdrop: false,
+            role: SurfaceRole::Overlay,
             layer: layer_surface,
             viewport,
             alpha_surface,
@@ -201,7 +202,7 @@ pub(crate) fn run(
 
         state.surfaces.push(OverlaySurface {
             output_name,
-            is_backdrop: true,
+            role: SurfaceRole::Backdrop,
             layer: backdrop_layer,
             viewport: None,
             alpha_surface: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,12 +19,21 @@ use wayland_protocols_wlr::gamma_control::v1::client::zwlr_gamma_control_v1::Zwl
 use crate::toplevel::TrackedToplevel;
 use crate::transition::Transition;
 
-pub(crate) struct OverlaySurface {
-    pub(crate) output_name: Option<String>,
+/// Distinguishes the two kinds of surfaces created per output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SurfaceRole {
+    /// Layer::Overlay — participates in transitions, skip logic, and all
+    /// optional protocol features (viewport, alpha surface, gamma control).
+    Overlay,
     /// Layer::Bottom backdrop — always opaque, never transitions.
     /// Prevents desktop flash when the compositor renders a frame
     /// before we receive foreign-toplevel events.
-    pub(crate) is_backdrop: bool,
+    Backdrop,
+}
+
+pub(crate) struct OverlaySurface {
+    pub(crate) output_name: Option<String>,
+    pub(crate) role: SurfaceRole,
     pub(crate) layer: LayerSurface,
     pub(crate) viewport: Option<WpViewport>,
     pub(crate) alpha_surface: Option<WpAlphaModifierSurfaceV1>,
@@ -34,6 +43,12 @@ pub(crate) struct OverlaySurface {
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) configured: bool,
+}
+
+impl OverlaySurface {
+    pub(crate) fn is_backdrop(&self) -> bool {
+        self.role == SurfaceRole::Backdrop
+    }
 }
 
 pub(crate) struct ZenState {
@@ -63,7 +78,7 @@ impl ZenState {
     /// Whether a surface should be skipped (transparent).
     /// Backdrops are never skipped — they're always opaque.
     pub(crate) fn is_skipped(&self, idx: usize) -> bool {
-        if self.surfaces[idx].is_backdrop {
+        if self.surfaces[idx].is_backdrop() {
             return false;
         }
         let name = self.surfaces[idx].output_name.as_deref();

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -59,7 +59,7 @@ impl ZenState {
             canvas[..4].copy_from_slice(&pixel.to_ne_bytes());
 
             for surface in self.surfaces.iter_mut() {
-                if surface.is_backdrop {
+                if surface.is_backdrop() {
                     continue;
                 }
                 if self

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -51,7 +51,7 @@ impl ZenState {
         // Immediately dim the old monitor's overlay
         if let Some(ref name) = old_active {
             for idx in 0..self.surfaces.len() {
-                if self.surfaces[idx].is_backdrop {
+                if self.surfaces[idx].is_backdrop() {
                     continue;
                 }
                 if self.surfaces[idx].output_name.as_deref() == Some(name) {
@@ -131,7 +131,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for ZenState {
                 if let Some(ref name) = prev_output_name {
                     let target_alpha = (state.target_opacity * 255.0) as u8;
                     for idx in 0..state.surfaces.len() {
-                        if state.surfaces[idx].is_backdrop {
+                        if state.surfaces[idx].is_backdrop() {
                             continue;
                         }
                         if state.surfaces[idx].output_name.as_deref() == Some(name.as_str()) {
@@ -173,7 +173,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for ZenState {
                     if is_active || is_revealing {
                         let target_alpha = (state.target_opacity * 255.0) as u8;
                         for idx in 0..state.surfaces.len() {
-                            if state.surfaces[idx].is_backdrop {
+                            if state.surfaces[idx].is_backdrop() {
                                 continue;
                             }
                             if state.surfaces[idx].output_name.as_deref() == Some(name) {

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -47,7 +47,7 @@ impl ZenState {
 
         // Only the newly active monitor's overlay fades — opaque → transparent
         for idx in 0..self.surfaces.len() {
-            if self.surfaces[idx].is_backdrop {
+            if self.surfaces[idx].is_backdrop() {
                 continue;
             }
             let name = self.surfaces[idx].output_name.as_deref();


### PR DESCRIPTION
Closes #4

Replace `OverlaySurface.is_backdrop: bool` with a `SurfaceRole` enum (`Overlay` / `Backdrop`) that makes the two surface kinds self-documenting. An `is_backdrop()` convenience method on `OverlaySurface` keeps call sites clean — no need to import the enum at every check.

### Changes

- **`state.rs`**: Add `SurfaceRole` enum with `Overlay` and `Backdrop` variants. Replace `is_backdrop: bool` field with `role: SurfaceRole`. Add `OverlaySurface::is_backdrop()` method.
- **`run.rs`**: Construct surfaces with `role: SurfaceRole::Overlay` / `SurfaceRole::Backdrop`.
- **`surface.rs`, `transition.rs`, `toplevel.rs`, `handlers.rs`**: Replace `surface.is_backdrop` / `surface.role == SurfaceRole::Backdrop` checks with `surface.is_backdrop()`.