### PR TITLE
test: add pure function tests

### DIFF
--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -95,3 +95,75 @@ impl Dispatch<ZwlrGammaControlV1, usize> for ZenState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use super::*;
+
+    fn read_ramp(size: u32, brightness: f64) -> Vec<u16> {
+        let mut file = create_gamma_ramp(size, brightness).unwrap();
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        buf.chunks_exact(2)
+            .map(|c| u16::from_ne_bytes([c[0], c[1]]))
+            .collect()
+    }
+
+    #[test]
+    fn gamma_ramp_size_one_full_brightness() {
+        let values = read_ramp(1, 1.0);
+        // 3 channels × 1 entry each
+        assert_eq!(values.len(), 3);
+        // i=0, divisor=max(0,1)=1 → 0/1 * 65535 = 0
+        assert!(values.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn gamma_ramp_zero_brightness() {
+        let values = read_ramp(256, 0.0);
+        assert_eq!(values.len(), 256 * 3);
+        assert!(values.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn gamma_ramp_full_brightness_linear() {
+        let values = read_ramp(256, 1.0);
+        assert_eq!(values.len(), 256 * 3);
+
+        // Each channel should be a linear ramp 0..65535
+        for channel in 0..3 {
+            let start = channel * 256;
+            assert_eq!(values[start], 0);
+            assert_eq!(values[start + 255], 65535);
+            // Monotonically increasing
+            for i in 1..256 {
+                assert!(values[start + i] >= values[start + i - 1]);
+            }
+        }
+    }
+
+    #[test]
+    fn gamma_ramp_half_brightness() {
+        let values = read_ramp(256, 0.5);
+        // Last entry of first channel: 65535 * 0.5 = 32767
+        assert_eq!(values[255], 32767);
+    }
+
+    #[test]
+    fn gamma_ramp_three_identical_channels() {
+        let values = read_ramp(256, 0.7);
+        let r = &values[0..256];
+        let g = &values[256..512];
+        let b = &values[512..768];
+        assert_eq!(r, g);
+        assert_eq!(g, b);
+    }
+
+    #[test]
+    fn gamma_ramp_size_zero() {
+        let values = read_ramp(0, 1.0);
+        assert!(values.is_empty());
+    }
+}

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -131,3 +131,45 @@ impl ZenState {
         surface.buffer = Some(buffer);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn premultiply_fully_opaque() {
+        assert_eq!(premultiply_argb(255, 128, 0, 255), 0xFF_FF_80_00);
+    }
+
+    #[test]
+    fn premultiply_fully_transparent() {
+        assert_eq!(premultiply_argb(255, 255, 255, 0), 0x00_00_00_00);
+    }
+
+    #[test]
+    fn premultiply_half_alpha() {
+        let result = premultiply_argb(255, 0, 0, 128);
+        let r = (result >> 16) & 0xFF;
+        let a = (result >> 24) & 0xFF;
+        assert_eq!(a, 128);
+        // 255 * 128 / 255 ≈ 128, with rounding: (255*128+127)/255 = 128
+        assert_eq!(r, 128);
+    }
+
+    #[test]
+    fn premultiply_all_max() {
+        assert_eq!(premultiply_argb(255, 255, 255, 255), 0xFF_FF_FF_FF);
+    }
+
+    #[test]
+    fn premultiply_all_zero() {
+        assert_eq!(premultiply_argb(0, 0, 0, 0), 0x00_00_00_00);
+    }
+
+    #[test]
+    fn premultiply_channel_order() {
+        // With full alpha, channels pass through unchanged
+        let result = premultiply_argb(0xAA, 0xBB, 0xCC, 0xFF);
+        assert_eq!(result, 0xFF_AA_BB_CC);
+    }
+}

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -65,3 +65,43 @@ impl ZenState {
         !done
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ease_out_quad_at_zero() {
+        assert!((ease_out_quad(0.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ease_out_quad_at_one() {
+        assert!((ease_out_quad(1.0) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ease_out_quad_at_half() {
+        // 1 - (1 - 0.5)^2 = 1 - 0.25 = 0.75
+        assert!((ease_out_quad(0.5) - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ease_out_quad_at_quarter() {
+        // 1 - (1 - 0.25)^2 = 1 - 0.5625 = 0.4375
+        assert!((ease_out_quad(0.25) - 0.4375).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ease_out_quad_is_monotonic() {
+        let steps: Vec<f64> = (0..=100).map(|i| i as f64 / 100.0).collect();
+        for pair in steps.windows(2) {
+            assert!(
+                ease_out_quad(pair[1]) >= ease_out_quad(pair[0]),
+                "ease_out_quad({}) < ease_out_quad({})",
+                pair[1],
+                pair[0],
+            );
+        }
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -223,3 +223,120 @@ impl ZenConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults() {
+        let b = ZenWindowBuilder::new();
+        assert!(b.skip_names.is_empty());
+        assert!(!b.skip_active);
+        assert_eq!(b.namespace, "wl-zenwindow");
+        assert!(b.settle_delay.is_none());
+        assert!(b.fade_duration.is_none());
+        assert_eq!(b.opacity, 1.0);
+        assert_eq!(b.color, [0, 0, 0]);
+        assert!(b.brightness.is_none());
+    }
+
+    #[test]
+    fn opacity_clamped_above() {
+        let b = ZenWindow::builder().opacity(1.5);
+        assert_eq!(b.opacity, 1.0);
+    }
+
+    #[test]
+    fn opacity_clamped_below() {
+        let b = ZenWindow::builder().opacity(-0.5);
+        assert_eq!(b.opacity, 0.0);
+    }
+
+    #[test]
+    fn opacity_within_range() {
+        let b = ZenWindow::builder().opacity(0.7);
+        assert!((b.opacity - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn brightness_clamped_above() {
+        let b = ZenWindow::builder().brightness(2.0);
+        assert_eq!(b.brightness, Some(1.0));
+    }
+
+    #[test]
+    fn brightness_clamped_below() {
+        let b = ZenWindow::builder().brightness(-1.0);
+        assert_eq!(b.brightness, Some(0.0));
+    }
+
+    #[test]
+    fn skip_output_accumulates() {
+        let b = ZenWindow::builder()
+            .skip_output("DP-1")
+            .skip_output("eDP-1");
+        assert!(b.skip_names.contains("DP-1"));
+        assert!(b.skip_names.contains("eDP-1"));
+        assert_eq!(b.skip_names.len(), 2);
+    }
+
+    #[test]
+    fn builder_chaining() {
+        let b = ZenWindow::builder()
+            .skip_active()
+            .namespace("custom")
+            .color(255, 0, 128)
+            .opacity(0.5)
+            .brightness(0.3)
+            .settle_delay(Duration::from_millis(200))
+            .fade_in(Duration::from_millis(500));
+
+        assert!(b.skip_active);
+        assert_eq!(b.namespace, "custom");
+        assert_eq!(b.color, [255, 0, 128]);
+        assert!((b.opacity - 0.5).abs() < f64::EPSILON);
+        assert_eq!(b.brightness, Some(0.3));
+        assert_eq!(b.settle_delay, Some(Duration::from_millis(200)));
+        assert_eq!(b.fade_duration, Some(Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn config_from_builder_transfers_all_fields() {
+        let b = ZenWindow::builder()
+            .skip_output("HDMI-1")
+            .skip_active()
+            .namespace("test-ns")
+            .settle_delay(Duration::from_millis(100))
+            .fade_in(Duration::from_secs(1))
+            .opacity(0.8)
+            .color(10, 20, 30)
+            .brightness(0.6);
+
+        let config = ZenConfig::from_builder(&b);
+
+        assert!(config.skip_names.contains("HDMI-1"));
+        assert!(config.skip_active);
+        assert_eq!(config.namespace, "test-ns");
+        assert_eq!(config.settle_delay, Some(Duration::from_millis(100)));
+        assert_eq!(config.fade_duration, Some(Duration::from_secs(1)));
+        assert!((config.target_opacity - 0.8).abs() < f64::EPSILON);
+        assert_eq!(config.color, [10, 20, 30]);
+        assert_eq!(config.brightness, Some(0.6));
+    }
+
+    #[test]
+    fn config_from_builder_defaults() {
+        let b = ZenWindowBuilder::new();
+        let config = ZenConfig::from_builder(&b);
+
+        assert!(config.skip_names.is_empty());
+        assert!(!config.skip_active);
+        assert_eq!(config.namespace, "wl-zenwindow");
+        assert!(config.settle_delay.is_none());
+        assert!(config.fade_duration.is_none());
+        assert_eq!(config.target_opacity, 1.0);
+        assert_eq!(config.color, [0, 0, 0]);
+        assert!(config.brightness.is_none());
+    }
+}


### PR DESCRIPTION
Adds inline unit tests for all Phase 1 targets from #11:

- `premultiply_argb()` in `surface.rs` (6 tests)
- `ease_out_quad()` in `transition.rs` (5 tests)
- `create_gamma_ramp()` in `gamma.rs` (6 tests)
- Builder defaults, opacity/brightness clamping, and `ZenConfig::from_builder()` in `window.rs` (10 tests)

27 tests total, all inline `#[cfg(test)]` modules.

Ref #11