### PR TITLE
refactor: extract skip logic as pure function

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -74,24 +74,184 @@ pub(crate) struct ZenState {
     pub(crate) running: bool,
 }
 
+/// Whether a surface should be skipped (left transparent).
+///
+/// Backdrops are never skipped — they're always opaque.
+/// An overlay is skipped when its output is in `skip_names`,
+/// or when `skip_active` is true and its output is the active one.
+pub(crate) fn should_skip(
+    role: SurfaceRole,
+    output_name: Option<&str>,
+    skip_names: &HashSet<String>,
+    skip_active: bool,
+    active_output: Option<&str>,
+) -> bool {
+    if role == SurfaceRole::Backdrop {
+        return false;
+    }
+    if let Some(name) = output_name {
+        if skip_names.contains(name) {
+            return true;
+        }
+        if skip_active {
+            if let Some(active) = active_output {
+                return name == active;
+            }
+        }
+    }
+    false
+}
+
 impl ZenState {
     /// Whether a surface should be skipped (transparent).
-    /// Backdrops are never skipped — they're always opaque.
     pub(crate) fn is_skipped(&self, idx: usize) -> bool {
-        if self.surfaces[idx].is_backdrop() {
-            return false;
-        }
-        let name = self.surfaces[idx].output_name.as_deref();
-        if let Some(name) = name {
-            if self.skip_names.contains(name) {
-                return true;
-            }
-            if self.skip_active {
-                if let Some(ref active) = self.active_output {
-                    return name == active;
-                }
-            }
-        }
-        false
+        let surface = &self.surfaces[idx];
+        should_skip(
+            surface.role,
+            surface.output_name.as_deref(),
+            &self.skip_names,
+            self.skip_active,
+            self.active_output.as_deref(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn skip_names(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn backdrop_never_skipped() {
+        assert!(!should_skip(
+            SurfaceRole::Backdrop,
+            Some("DP-1"),
+            &skip_names(&["DP-1"]),
+            true,
+            Some("DP-1"),
+        ));
+    }
+
+    #[test]
+    fn overlay_skipped_by_name() {
+        assert!(should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &skip_names(&["DP-1"]),
+            false,
+            None,
+        ));
+    }
+
+    #[test]
+    fn overlay_not_skipped_when_name_not_in_set() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &skip_names(&["HDMI-1"]),
+            false,
+            None,
+        ));
+    }
+
+    #[test]
+    fn overlay_skipped_when_active() {
+        assert!(should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &HashSet::new(),
+            true,
+            Some("DP-1"),
+        ));
+    }
+
+    #[test]
+    fn overlay_not_skipped_when_skip_active_false() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &HashSet::new(),
+            false,
+            Some("DP-1"),
+        ));
+    }
+
+    #[test]
+    fn overlay_not_skipped_when_different_output_active() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &HashSet::new(),
+            true,
+            Some("HDMI-1"),
+        ));
+    }
+
+    #[test]
+    fn overlay_not_skipped_when_no_active_output() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &HashSet::new(),
+            true,
+            None,
+        ));
+    }
+
+    #[test]
+    fn overlay_without_name_never_skipped() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            None,
+            &skip_names(&["DP-1"]),
+            true,
+            Some("DP-1"),
+        ));
+    }
+
+    #[test]
+    fn skip_name_takes_priority_over_active() {
+        // Output is in skip_names AND is the active output —
+        // should be skipped regardless of skip_active flag.
+        assert!(should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &skip_names(&["DP-1"]),
+            false,
+            Some("DP-1"),
+        ));
+    }
+
+    #[test]
+    fn multiple_skip_names() {
+        let names = skip_names(&["DP-1", "DP-2", "HDMI-1"]);
+        assert!(should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-2"),
+            &names,
+            false,
+            None
+        ));
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("eDP-1"),
+            &names,
+            false,
+            None
+        ));
+    }
+
+    #[test]
+    fn empty_skip_names_and_no_active() {
+        assert!(!should_skip(
+            SurfaceRole::Overlay,
+            Some("DP-1"),
+            &HashSet::new(),
+            false,
+            None,
+        ));
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,6 +1,7 @@
 use smithay_client_toolkit::shell::WaylandSurface;
 use wayland_client::protocol::wl_shm;
 
+use crate::state::should_skip;
 use crate::state::ZenState;
 
 pub(crate) fn premultiply_argb(r: u8, g: u8, b: u8, a: u8) -> u32 {
@@ -59,14 +60,14 @@ impl ZenState {
             canvas[..4].copy_from_slice(&pixel.to_ne_bytes());
 
             for surface in self.surfaces.iter_mut() {
-                if surface.is_backdrop() {
-                    continue;
-                }
-                if self
-                    .skip_names
-                    .contains(surface.output_name.as_deref().unwrap_or(""))
-                    || (self.skip_active
-                        && self.active_output.as_deref() == surface.output_name.as_deref())
+                if surface.is_backdrop()
+                    || should_skip(
+                        surface.role,
+                        surface.output_name.as_deref(),
+                        &self.skip_names,
+                        self.skip_active,
+                        self.active_output.as_deref(),
+                    )
                 {
                     continue;
                 }


### PR DESCRIPTION
Extract the skip predicate into a pure free function `should_skip()` that takes data parameters instead of `&self`, providing a single source of truth for skip logic.

## Changes

- **`state.rs`**: Add `should_skip(role, output_name, skip_names, skip_active, active_output) -> bool` as a pure free function. Rewrite `ZenState::is_skipped()` to delegate to it.
- **`surface.rs`**: Replace the duplicated inline skip logic in `draw_dimmed()` with a call to `should_skip()`, eliminating the manual sync requirement between the two implementations.
- **`state.rs` tests**: Add 11 tests covering all branches — backdrop immunity, name matching, active output matching, edge cases (no name, no active output, empty skip set), and priority behavior.

## Motivation

The skip predicate was duplicated between `is_skipped()` (`state.rs`) and `draw_dimmed()` (`surface.rs`) because `draw_dimmed()` needs `&mut self` to iterate surfaces while `is_skipped()` takes `&self`. The two had to stay in sync manually — a bug waiting to happen.

Extracting to a free function that takes data by parameter solves the borrow conflict and makes the logic independently testable.

Closes #7
Partially addresses #11 (Phase 2: refactor for testability)