### PR TITLE
Refactor render.rs: domain types, method-based API, consolidated logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,6 @@
 
 use smithay_client_toolkit::shell::wlr_layer::Anchor;
 use smithay_client_toolkit::shell::wlr_layer::KeyboardInteractivity;
-use smithay_client_toolkit::shell::wlr_layer::Layer;
 use smithay_client_toolkit::shell::wlr_layer::LayerSurface;
 use smithay_client_toolkit::shell::WaylandSurface;
 use wayland_client::protocol::wl_output::WlOutput;
@@ -36,12 +35,11 @@ use wayland_client::QueueHandle;
 
 use crate::dim::DimController;
 use crate::dim::DimUpdates;
-use crate::render::alpha_to_u8;
-use crate::render::draw_surface;
-use crate::render::update_gamma;
+use crate::render::Brightness;
 use crate::render::GammaState;
+use crate::render::LayerShellHandshake;
+use crate::render::Opacity;
 use crate::render::Surface;
-use crate::render::SurfaceConfig;
 use crate::render::SurfaceRole;
 use crate::wayland::TrackedToplevel;
 use crate::wayland::Wayland;
@@ -116,15 +114,10 @@ impl App {
             .as_ref()
             .map(|vp| vp.get_viewport(&wl_surface, qh, ()));
 
-        let layer = match role {
-            SurfaceRole::Backdrop => Layer::Top,
-            SurfaceRole::Overlay => Layer::Overlay,
-        };
-
         let layer_surface = self.wl.layer_shell.create_layer_surface(
             qh,
             wl_surface,
-            layer,
+            role.into(),
             Some(self.config.namespace.clone()),
             Some(output),
         );
@@ -169,7 +162,7 @@ impl App {
             alpha_modifier,
             gamma,
             buffer: None,
-            config: SurfaceConfig::Pending,
+            configure: LayerShellHandshake::Pending,
         });
     }
 
@@ -177,7 +170,7 @@ impl App {
     pub fn all_surfaces_configured(&self) -> bool {
         self.surfaces
             .iter()
-            .all(|s| !matches!(s.config, SurfaceConfig::Pending))
+            .all(|s| !matches!(s.configure, LayerShellHandshake::Pending))
     }
 
     /// Get the currently active output name from toplevel tracking.
@@ -193,23 +186,22 @@ impl App {
     /// Apply dimming updates to overlay surfaces only.
     pub fn apply_updates(&mut self, updates: &DimUpdates) {
         for update in updates.iter() {
-            self.apply_output_update(&update.name, update.alpha, update.brightness);
+            self.apply_output_update(&update.name, update.opacity, update.brightness);
         }
     }
 
     /// Apply a single output update to its overlay surface.
-    pub fn apply_output_update(&mut self, name: &str, alpha: f64, brightness: f64) {
+    pub fn apply_output_update(&mut self, name: &str, opacity: Opacity, brightness: Brightness) {
         let has_viewporter = self.wl.has_viewporter();
         let color = self.config.color;
-        let alpha_u8 = alpha_to_u8(alpha);
 
         if let Some(surface) = self
             .surfaces
             .iter_mut()
             .find(|s| s.output_name.as_deref() == Some(name) && s.role == SurfaceRole::Overlay)
         {
-            draw_surface(surface, &mut self.wl.pool, color, alpha_u8, has_viewporter);
-            update_gamma(surface, brightness);
+            surface.draw(&mut self.wl.pool, color, opacity, has_viewporter);
+            surface.update_gamma(brightness);
         }
     }
 
@@ -219,27 +211,25 @@ impl App {
         let color = self.config.color;
 
         for update in updates.iter() {
-            let alpha = alpha_to_u8(update.alpha);
-
             for surface in &mut self.surfaces {
                 if surface.output_name.as_deref() != Some(&update.name) {
                     continue;
                 }
-                draw_surface(surface, &mut self.wl.pool, color, alpha, has_viewporter);
-                update_gamma(surface, update.brightness);
+                surface.draw(&mut self.wl.pool, color, update.opacity, has_viewporter);
+                surface.update_gamma(update.brightness);
             }
         }
     }
 
     /// Snap all backdrops to `target_opacity` (called after fade-in).
     pub fn snap_backdrops_to_target(&mut self) {
-        let alpha = alpha_to_u8(self.config.target_opacity);
         let has_viewporter = self.wl.has_viewporter();
         let color = self.config.color;
+        let opacity = self.config.target_opacity;
 
         for surface in &mut self.surfaces {
             if surface.role == SurfaceRole::Backdrop {
-                draw_surface(surface, &mut self.wl.pool, color, alpha, has_viewporter);
+                surface.draw(&mut self.wl.pool, color, opacity, has_viewporter);
             }
         }
     }

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -32,6 +32,9 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::render::Brightness;
+use crate::render::Opacity;
+
 /// Per-output dimming state.
 ///
 /// This is the source of truth for "what should this output look like."
@@ -60,8 +63,8 @@ impl std::ops::Deref for DimUpdates {
 #[derive(Debug, Clone)]
 pub struct OutputUpdate {
     pub name: String,
-    pub alpha: f64,
-    pub brightness: f64,
+    pub opacity: Opacity,
+    pub brightness: Brightness,
 }
 
 /// Owns all dimming logic. Computes alpha AND gamma together.
@@ -172,8 +175,8 @@ impl DimController {
                 state.brightness = self.target_brightness;
                 updates.push(OutputUpdate {
                     name: name.clone(),
-                    alpha: state.alpha,
-                    brightness: state.brightness,
+                    opacity: Opacity::new(state.alpha),
+                    brightness: Brightness::new(state.brightness),
                 });
             }
         }
@@ -224,8 +227,8 @@ impl DimController {
             state.brightness = self.target_brightness + (1.0 - self.target_brightness) * eased;
             updates.push(OutputUpdate {
                 name: revealing,
-                alpha: state.alpha,
-                brightness: state.brightness,
+                opacity: Opacity::new(state.alpha),
+                brightness: Brightness::new(state.brightness),
             });
         }
 
@@ -262,8 +265,8 @@ impl DimController {
             }
             updates.push(OutputUpdate {
                 name: name.clone(),
-                alpha: state.alpha,
-                brightness: state.brightness,
+                opacity: Opacity::new(state.alpha),
+                brightness: Brightness::new(state.brightness),
             });
         }
 
@@ -284,8 +287,8 @@ impl DimController {
             }
             updates.push(OutputUpdate {
                 name: name.clone(),
-                alpha: state.alpha,
-                brightness: state.brightness,
+                opacity: Opacity::new(state.alpha),
+                brightness: Brightness::new(state.brightness),
             });
         }
 
@@ -296,8 +299,8 @@ impl DimController {
     pub fn current_update(&self, name: &str) -> Option<OutputUpdate> {
         self.outputs.get(name).map(|state| OutputUpdate {
             name: name.to_string(),
-            alpha: state.alpha,
-            brightness: state.brightness,
+            opacity: Opacity::new(state.alpha),
+            brightness: Brightness::new(state.brightness),
         })
     }
 
@@ -317,8 +320,8 @@ impl DimController {
             state.brightness = self.target_brightness;
             updates.push(OutputUpdate {
                 name: name.clone(),
-                alpha: state.alpha,
-                brightness: state.brightness,
+                opacity: Opacity::new(state.alpha),
+                brightness: Brightness::new(state.brightness),
             });
         }
 
@@ -370,8 +373,8 @@ mod tests {
         // DP-1 should be immediately dimmed
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].name, "DP-1");
-        assert_eq!(updates[0].alpha, 0.8);
-        assert_eq!(updates[0].brightness, 0.5);
+        assert_eq!(updates[0].opacity.as_f64(), 0.8);
+        assert_eq!(updates[0].brightness.as_f64(), 0.5);
 
         // DP-2 should now be skipped, transition started
         assert!(ctrl.is_skipped("DP-2"));
@@ -401,10 +404,10 @@ mod tests {
         let updates = ctrl.tick();
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].name, "DP-2");
-        // Alpha should be decreasing toward 0
-        assert!(updates[0].alpha < 1.0);
+        // Opacity should be decreasing toward 0
+        assert!(updates[0].opacity.as_f64() < 1.0);
         // Brightness should be increasing toward 1
-        assert!(updates[0].brightness > 0.5);
+        assert!(updates[0].brightness.as_f64() > 0.5);
     }
 
     #[test]
@@ -419,12 +422,12 @@ mod tests {
         let dp2 = updates.iter().find(|u| u.name == "DP-2").unwrap();
 
         // DP-1 is skipped (active): stays transparent
-        assert_eq!(dp1.alpha, 0.0);
-        assert_eq!(dp1.brightness, 1.0);
+        assert_eq!(dp1.opacity.as_f64(), 0.0);
+        assert_eq!(dp1.brightness.as_f64(), 1.0);
 
         // DP-2 is not skipped: fading toward target
-        assert!(dp2.alpha > 0.0);
-        assert!(dp2.brightness < 1.0);
+        assert!(dp2.opacity.as_f64() > 0.0);
+        assert!(dp2.brightness.as_f64() < 1.0);
     }
 
     #[test]
@@ -458,9 +461,9 @@ mod tests {
         let dp1 = updates.iter().find(|u| u.name == "DP-1").unwrap();
         let dp2 = updates.iter().find(|u| u.name == "DP-2").unwrap();
 
-        assert_eq!(dp1.alpha, 0.0);
-        assert_eq!(dp1.brightness, 1.0);
-        assert_eq!(dp2.alpha, 0.8);
-        assert_eq!(dp2.brightness, 0.4);
+        assert_eq!(dp1.opacity.as_f64(), 0.0);
+        assert_eq!(dp1.brightness.as_f64(), 1.0);
+        assert_eq!(dp2.opacity.as_f64(), 0.8);
+        assert_eq!(dp2.brightness.as_f64(), 0.4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,5 +148,8 @@ mod wayland;
 mod window;
 
 pub use error::SpawnError;
+pub use render::Brightness;
+pub use render::Color;
+pub use render::Opacity;
 pub use window::ZenWindow;
 pub use window::ZenWindowBuilder;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,8 +1,8 @@
 //! Surface types and rendering operations.
 //!
-//! Defines per-output [`Surface`] state and the pure functions that draw
-//! overlays and update gamma. All Wayland buffer and protocol interactions
-//! for rendering live here.
+//! Defines per-output [`Surface`] state and the methods that draw overlays
+//! and update gamma. All Wayland buffer and protocol interactions for
+//! rendering live here.
 //!
 //! # Dual-layer architecture
 //!
@@ -22,7 +22,7 @@
 //!
 //! # Rendering paths
 //!
-//! [`draw_surface`] picks the most efficient available path:
+//! [`Surface::draw`] picks the most efficient available path:
 //!
 //! 1. Alpha modifier + viewporter — 1×1 opaque buffer, compositor blends
 //! 2. Viewporter only — 1×1 premultiplied ARGB, scaled up
@@ -31,15 +31,19 @@
 //! # Types
 //!
 //! - [`Surface`] — layer, viewport, alpha modifier, gamma, buffer state
-//! - [`SurfaceConfig`] — `Pending` until compositor sends dimensions
+//! - [`LayerShellHandshake`] — `Pending` until compositor sends dimensions
 //! - [`SurfaceRole`] — `Backdrop` vs `Overlay`
 //! - [`GammaState`] — `Unavailable` / `Pending` / `Ready`
+//! - [`Color`] — overlay color
+//! - [`Opacity`] — normalized opacity value (0.0–1.0)
+//! - [`Brightness`] — monitor brightness level (0.0–1.0)
 
 use std::io::Seek;
 use std::io::Write;
 use std::os::fd::AsFd;
 use std::os::fd::FromRawFd;
 
+use smithay_client_toolkit::shell::wlr_layer::Layer;
 use smithay_client_toolkit::shell::wlr_layer::LayerSurface;
 use smithay_client_toolkit::shell::WaylandSurface;
 use smithay_client_toolkit::shm::slot::Buffer;
@@ -49,14 +53,191 @@ use wayland_protocols::wp::alpha_modifier::v1::client::wp_alpha_modifier_surface
 use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use wayland_protocols_wlr::gamma_control::v1::client::zwlr_gamma_control_v1::ZwlrGammaControlV1;
 
-/// Surface configuration state.
+/// RGB color for overlay surfaces.
+///
+/// A simple color type that can be constructed from individual components
+/// or converted from a `[u8; 3]` array.
+///
+/// # Examples
+///
+/// ```
+/// use wl_zenwindow::Color;
+///
+/// let black = Color::BLACK;
+/// let red = Color::new(255, 0, 0);
+/// let from_array: Color = [0x1a, 0x1a, 0x1a].into();
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Color {
+    /// Red component (0–255).
+    pub r: u8,
+    /// Green component (0–255).
+    pub g: u8,
+    /// Blue component (0–255).
+    pub b: u8,
+}
+
+impl Color {
+    /// Black (`#000000`).
+    pub const BLACK: Self = Self { r: 0, g: 0, b: 0 };
+
+    /// White (`#FFFFFF`).
+    pub const WHITE: Self = Self {
+        r: 255,
+        g: 255,
+        b: 255,
+    };
+
+    /// Create a new RGB color.
+    #[must_use]
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+}
+
+impl From<[u8; 3]> for Color {
+    fn from([r, g, b]: [u8; 3]) -> Self {
+        Self { r, g, b }
+    }
+}
+
+impl From<Color> for [u8; 3] {
+    fn from(rgb: Color) -> Self {
+        [rgb.r, rgb.g, rgb.b]
+    }
+}
+
+/// Opacity value, clamped to 0.0–1.0.
+///
+/// Represents how opaque a surface should be. `0.0` is fully transparent,
+/// `1.0` is fully opaque. Values outside this range are clamped on construction.
+///
+/// Internally stores the normalized `f64` value, but provides conversion to
+/// `u8` (0–255) for buffer operations.
+///
+/// # Examples
+///
+/// ```
+/// use wl_zenwindow::Opacity;
+///
+/// let half = Opacity::new(0.5);
+/// assert_eq!(half.as_u8(), 127);
+///
+/// let clamped = Opacity::new(1.5); // clamped to 1.0
+/// assert_eq!(clamped.as_f64(), 1.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Opacity(f64);
+
+impl Opacity {
+    /// Fully transparent.
+    pub const TRANSPARENT: Self = Self(0.0);
+
+    /// Fully opaque.
+    pub const OPAQUE: Self = Self(1.0);
+
+    /// Create a new opacity value, clamping to 0.0–1.0.
+    #[must_use]
+    pub fn new(value: f64) -> Self {
+        Self(value.clamp(0.0, 1.0))
+    }
+
+    /// Get the opacity as a normalized f64 (0.0–1.0).
+    #[must_use]
+    pub fn as_f64(self) -> f64 {
+        self.0
+    }
+
+    /// Get the opacity as a u8 (0–255) for buffer operations.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn as_u8(self) -> u8 {
+        (self.0 * 255.0) as u8
+    }
+}
+
+impl From<f64> for Opacity {
+    fn from(value: f64) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Monitor brightness level, clamped to 0.0–1.0.
+///
+/// Controls monitor brightness via the `zwlr_gamma_control_v1` protocol.
+/// `0.0` is completely dark, `1.0` is normal brightness.
+///
+/// # Examples
+///
+/// ```
+/// use wl_zenwindow::Brightness;
+///
+/// let dim = Brightness::new(0.7);
+/// assert_eq!(dim.as_f64(), 0.7);
+///
+/// let clamped = Brightness::new(1.5); // clamped to 1.0
+/// assert_eq!(clamped.as_f64(), 1.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Brightness(f64);
+
+impl Brightness {
+    /// Completely dark.
+    pub const DARK: Self = Self(0.0);
+
+    /// Normal brightness.
+    pub const NORMAL: Self = Self(1.0);
+
+    /// Create a new brightness value, clamping to 0.0–1.0.
+    #[must_use]
+    pub fn new(value: f64) -> Self {
+        Self(value.clamp(0.0, 1.0))
+    }
+
+    /// Get the brightness as a normalized f64 (0.0–1.0).
+    #[must_use]
+    pub fn as_f64(self) -> f64 {
+        self.0
+    }
+}
+
+impl From<f64> for Brightness {
+    fn from(value: f64) -> Self {
+        Self::new(value)
+    }
+}
+
+/// State of the layer-shell configure handshake.
+///
+/// In Wayland's layer-shell protocol, clients can't just create a surface and
+/// start drawing — they must wait for the compositor to tell them their
+/// dimensions first. This happens through a "configure" event that the
+/// compositor sends after the client commits an initial (empty) surface.
+///
+/// The handshake flow:
+/// 1. Client creates a layer surface and commits it (no buffer attached)
+/// 2. Compositor sends a `configure` event with the surface dimensions
+/// 3. Client can now create appropriately-sized buffers and draw
+///
+/// Surfaces start [`Pending`](Self::Pending) and transition to
+/// [`Ready`](Self::Ready) once the compositor sends dimensions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SurfaceConfig {
+pub enum LayerShellHandshake {
+    /// Waiting for the compositor to send dimensions.
+    ///
+    /// The surface has been created and committed, but we haven't received
+    /// the configure event yet. Drawing is not possible in this state.
     Pending,
+    /// Compositor has configured the surface with these dimensions.
+    ///
+    /// The surface is ready to draw. Width and height may be zero if the
+    /// compositor hasn't assigned real dimensions yet (e.g., the output
+    /// is disabled).
     Ready { width: u32, height: u32 },
 }
 
-impl SurfaceConfig {
+impl LayerShellHandshake {
+    /// Returns dimensions if configured and non-zero.
     pub fn dimensions(&self) -> Option<(u32, u32)> {
         match self {
             Self::Ready { width, height } if *width > 0 && *height > 0 => Some((*width, *height)),
@@ -66,23 +247,64 @@ impl SurfaceConfig {
 }
 
 /// Per-surface gamma control state.
+///
+/// Tracks the `zwlr_gamma_control_v1` protocol handshake. Like layer-shell,
+/// gamma control requires a back-and-forth with the compositor:
+///
+/// 1. Client requests gamma control for an output
+/// 2. Compositor sends `gamma_size` event with the ramp size (or `failed`)
+/// 3. Client can now set gamma ramps
+///
+/// If another client already owns gamma control (e.g., `wlsunset`), the
+/// compositor sends `failed` and we fall back to [`Unavailable`](Self::Unavailable).
 #[derive(Debug)]
 pub enum GammaState {
+    /// Gamma control not available (protocol missing or another client owns it).
     Unavailable,
+    /// Waiting for the compositor to report gamma ramp size.
     Pending(ZwlrGammaControlV1),
+    /// Ready to set gamma ramps.
     Ready {
         control: ZwlrGammaControlV1,
         size: u32,
     },
 }
 
+impl GammaState {
+    /// Handle the `gamma_size` event — transition from `Pending` to `Ready`.
+    ///
+    /// If not currently `Pending`, this is a no-op.
+    pub fn receive_size(&mut self, size: u32) {
+        if let Self::Pending(control) = std::mem::replace(self, Self::Unavailable) {
+            *self = Self::Ready { control, size };
+        }
+    }
+
+    /// Handle the `failed` event — transition to `Unavailable`.
+    ///
+    /// Called when the compositor rejects our gamma control request
+    /// (typically because another client like `wlsunset` already owns it).
+    pub fn fail(&mut self) {
+        *self = Self::Unavailable;
+    }
+}
+
 /// Role of a surface in the dual-layer architecture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SurfaceRole {
-    /// Backdrop at `Layer::Top` - above waybar/panels, safety net during transitions.
+    /// Backdrop at `Layer::Top` — above waybar/panels, safety net during transitions.
     Backdrop,
-    /// Overlay at `Layer::Overlay` - above everything, handles fades.
+    /// Overlay at `Layer::Overlay` — above everything, handles fades.
     Overlay,
+}
+
+impl From<SurfaceRole> for Layer {
+    fn from(role: SurfaceRole) -> Self {
+        match role {
+            SurfaceRole::Backdrop => Layer::Top,
+            SurfaceRole::Overlay => Layer::Overlay,
+        }
+    }
 }
 
 /// A managed overlay surface.
@@ -94,131 +316,127 @@ pub struct Surface {
     pub alpha_modifier: Option<WpAlphaModifierSurfaceV1>,
     pub gamma: GammaState,
     pub buffer: Option<Buffer>,
-    pub config: SurfaceConfig,
+    pub configure: LayerShellHandshake,
 }
 
-/// Convert alpha from f64 (0.0–1.0) to u8 (0–255).
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // 0.0–1.0 × 255 fits in u8
-pub fn alpha_to_u8(alpha: f64) -> u8 {
-    (alpha * 255.0) as u8
-}
+impl Surface {
+    /// Draw the surface at the given opacity level.
+    ///
+    /// Picks the most efficient rendering path based on available protocols:
+    /// 1. Alpha modifier + viewporter — 1×1 opaque buffer, compositor blends
+    /// 2. Viewporter only — 1×1 premultiplied ARGB, scaled up
+    /// 3. Neither — full-resolution buffer fill
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn draw(
+        &mut self,
+        pool: &mut SlotPool,
+        color: Color,
+        opacity: Opacity,
+        has_viewporter: bool,
+    ) {
+        let Some((width, height)) = self.configure.dimensions() else {
+            return;
+        };
 
-/// Premultiply RGB values by alpha for ARGB8888 format.
-#[allow(clippy::cast_possible_truncation)] // Math guarantees result fits in u8
-pub fn premultiply_argb(r: u8, g: u8, b: u8, a: u8) -> u32 {
-    let a16 = u16::from(a);
-    let r_pre = ((u16::from(r) * a16 + 127) / 255) as u8;
-    let g_pre = ((u16::from(g) * a16 + 127) / 255) as u8;
-    let b_pre = ((u16::from(b) * a16 + 127) / 255) as u8;
-    u32::from(a) << 24 | u32::from(r_pre) << 16 | u32::from(g_pre) << 8 | u32::from(b_pre)
-}
-
-/// Draw a surface at the given alpha level.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // alpha multiplier math
-pub fn draw_surface(
-    surface: &mut Surface,
-    pool: &mut SlotPool,
-    color: [u8; 3],
-    alpha: u8,
-    has_viewporter: bool,
-) {
-    let Some((width, height)) = surface.config.dimensions() else {
-        return;
-    };
-
-    let width_i32 = width.cast_signed();
-    let height_i32 = height.cast_signed();
-
-    // Use alpha modifier if available (more efficient, compositor-side blending)
-    if let Some(ref alpha_surf) = surface.alpha_modifier {
-        let multiplier = (f64::from(alpha) / 255.0 * f64::from(u32::MAX)) as u32;
-        alpha_surf.set_multiplier(multiplier);
-
-        // Draw opaque buffer, let compositor handle alpha
-        if has_viewporter {
-            draw_1x1_scaled(surface, pool, color, 255, width_i32, height_i32);
+        // If compositor handles alpha, draw opaque and let it blend.
+        // Otherwise, bake alpha into the buffer.
+        let buffer_alpha = if let Some(ref alpha_surf) = self.alpha_modifier {
+            let multiplier = (opacity.as_f64() * f64::from(u32::MAX)) as u32;
+            alpha_surf.set_multiplier(multiplier);
+            255
         } else {
-            draw_fullsize(surface, pool, color, 255);
-        }
-    } else if has_viewporter {
-        // No alpha modifier, bake alpha into buffer
-        draw_1x1_scaled(surface, pool, color, alpha, width_i32, height_i32);
-    } else {
-        draw_fullsize(surface, pool, color, alpha);
-    }
-}
+            opacity.as_u8()
+        };
 
-fn draw_1x1_scaled(
-    surface: &mut Surface,
-    pool: &mut SlotPool,
-    color: [u8; 3],
-    alpha: u8,
-    width: i32,
-    height: i32,
-) {
-    let [red, green, blue] = color;
-
-    let (buffer, canvas) = pool
-        .create_buffer(1, 1, 4, wl_shm::Format::Argb8888)
-        .expect("failed to create 1x1 buffer");
-
-    let pixel = premultiply_argb(red, green, blue, alpha);
-    canvas[..4].copy_from_slice(&pixel.to_ne_bytes());
-
-    if let Some(ref viewport) = surface.viewport {
-        viewport.set_destination(width, height);
-    }
-    surface
-        .layer
-        .wl_surface()
-        .attach(Some(buffer.wl_buffer()), 0, 0);
-    surface.layer.wl_surface().damage_buffer(0, 0, 1, 1);
-    surface.layer.commit();
-    surface.buffer = Some(buffer);
-}
-
-#[allow(clippy::cast_ptr_alignment)] // ARGB8888 buffer is 4-byte aligned
-fn draw_fullsize(surface: &mut Surface, pool: &mut SlotPool, color: [u8; 3], alpha: u8) {
-    let Some((width, height)) = surface.config.dimensions() else {
-        return;
-    };
-
-    let width_i32 = width.cast_signed();
-    let height_i32 = height.cast_signed();
-    let stride = width_i32 * 4;
-    let [red, green, blue] = color;
-
-    surface.buffer = None;
-
-    let (buffer, canvas) = pool
-        .create_buffer(width_i32, height_i32, stride, wl_shm::Format::Argb8888)
-        .expect("failed to create buffer");
-
-    let pixel = premultiply_argb(red, green, blue, alpha);
-    let pixels: &mut [u32] = unsafe {
-        std::slice::from_raw_parts_mut(canvas.as_mut_ptr().cast::<u32>(), canvas.len() / 4)
-    };
-    pixels.fill(pixel);
-
-    surface
-        .layer
-        .wl_surface()
-        .attach(Some(buffer.wl_buffer()), 0, 0);
-    surface
-        .layer
-        .wl_surface()
-        .damage_buffer(0, 0, width_i32, height_i32);
-    surface.layer.commit();
-    surface.buffer = Some(buffer);
-}
-
-/// Update gamma for a surface.
-pub fn update_gamma(surface: &Surface, brightness: f64) {
-    if let GammaState::Ready { ref control, size } = surface.gamma {
-        if let Ok(ramp) = create_gamma_ramp(size, brightness) {
-            control.set_gamma(ramp.as_fd());
+        if has_viewporter {
+            self.draw_1x1_scaled(
+                pool,
+                color,
+                buffer_alpha,
+                width.cast_signed(),
+                height.cast_signed(),
+            );
+        } else {
+            self.draw_fullsize(pool, color, buffer_alpha);
         }
     }
+
+    /// Update gamma brightness for this surface.
+    pub fn update_gamma(&self, brightness: Brightness) {
+        if let GammaState::Ready { ref control, size } = self.gamma {
+            if let Ok(ramp) = create_gamma_ramp(size, brightness.as_f64()) {
+                control.set_gamma(ramp.as_fd());
+            }
+        }
+    }
+
+    fn draw_1x1_scaled(
+        &mut self,
+        pool: &mut SlotPool,
+        color: Color,
+        alpha: u8,
+        width: i32,
+        height: i32,
+    ) {
+        let (buffer, canvas) = pool
+            .create_buffer(1, 1, 4, wl_shm::Format::Argb8888)
+            .expect("failed to create 1x1 buffer");
+
+        let pixel = premultiply_argb(color, alpha);
+        canvas[..4].copy_from_slice(&pixel.to_ne_bytes());
+
+        if let Some(ref viewport) = self.viewport {
+            viewport.set_destination(width, height);
+        }
+        self.layer
+            .wl_surface()
+            .attach(Some(buffer.wl_buffer()), 0, 0);
+        self.layer.wl_surface().damage_buffer(0, 0, 1, 1);
+        self.layer.commit();
+        self.buffer = Some(buffer);
+    }
+
+    #[allow(clippy::cast_ptr_alignment)] // ARGB8888 buffer is 4-byte aligned
+    fn draw_fullsize(&mut self, pool: &mut SlotPool, color: Color, alpha: u8) {
+        let Some((width, height)) = self.configure.dimensions() else {
+            return;
+        };
+
+        let width_i32 = width.cast_signed();
+        let height_i32 = height.cast_signed();
+        let stride = width_i32 * 4;
+
+        self.buffer = None;
+
+        let (buffer, canvas) = pool
+            .create_buffer(width_i32, height_i32, stride, wl_shm::Format::Argb8888)
+            .expect("failed to create buffer");
+
+        let pixel = premultiply_argb(color, alpha);
+        let pixels: &mut [u32] = unsafe {
+            std::slice::from_raw_parts_mut(canvas.as_mut_ptr().cast::<u32>(), canvas.len() / 4)
+        };
+        pixels.fill(pixel);
+
+        self.layer
+            .wl_surface()
+            .attach(Some(buffer.wl_buffer()), 0, 0);
+        self.layer
+            .wl_surface()
+            .damage_buffer(0, 0, width_i32, height_i32);
+        self.layer.commit();
+        self.buffer = Some(buffer);
+    }
+}
+
+/// Premultiply RGB color by alpha for ARGB8888 format.
+#[allow(clippy::cast_possible_truncation)]
+fn premultiply_argb(color: Color, alpha: u8) -> u32 {
+    let a16 = u16::from(alpha);
+    let r_pre = ((u16::from(color.r) * a16 + 127) / 255) as u8;
+    let g_pre = ((u16::from(color.g) * a16 + 127) / 255) as u8;
+    let b_pre = ((u16::from(color.b) * a16 + 127) / 255) as u8;
+    u32::from(alpha) << 24 | u32::from(r_pre) << 16 | u32::from(g_pre) << 8 | u32::from(b_pre)
 }
 
 /// Create a gamma ramp file descriptor for the given size and brightness.
@@ -229,7 +447,7 @@ pub fn update_gamma(surface: &Surface, brightness: f64) {
     clippy::cast_possible_truncation, // Math guarantees result fits in u16
     clippy::cast_sign_loss            // Values are always positive
 )]
-pub fn create_gamma_ramp(size: u32, brightness: f64) -> std::io::Result<std::fs::File> {
+fn create_gamma_ramp(size: u32, brightness: f64) -> std::io::Result<std::fs::File> {
     let name = std::ffi::CString::new("wl-zenwindow-gamma").unwrap();
     let raw_fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
     if raw_fd < 0 {
@@ -254,65 +472,130 @@ pub fn create_gamma_ramp(size: u32, brightness: f64) -> std::io::Result<std::fs:
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use std::io::Read;
 
     use super::*;
 
     #[test]
-    fn surface_config_pending_has_no_dimensions() {
-        assert_eq!(SurfaceConfig::Pending.dimensions(), None);
+    fn layer_shell_handshake_pending_has_no_dimensions() {
+        assert_eq!(LayerShellHandshake::Pending.dimensions(), None);
     }
 
     #[test]
-    fn surface_config_ready_returns_dimensions() {
-        let config = SurfaceConfig::Ready {
+    fn layer_shell_handshake_ready_returns_dimensions() {
+        let state = LayerShellHandshake::Ready {
             width: 1920,
             height: 1080,
         };
-        assert_eq!(config.dimensions(), Some((1920, 1080)));
+        assert_eq!(state.dimensions(), Some((1920, 1080)));
     }
 
     #[test]
-    fn surface_config_ready_zero_width_returns_none() {
-        let config = SurfaceConfig::Ready {
+    fn layer_shell_handshake_ready_zero_width_returns_none() {
+        let state = LayerShellHandshake::Ready {
             width: 0,
             height: 1080,
         };
-        assert_eq!(config.dimensions(), None);
+        assert_eq!(state.dimensions(), None);
     }
 
     #[test]
-    fn surface_config_ready_zero_height_returns_none() {
-        let config = SurfaceConfig::Ready {
+    fn layer_shell_handshake_ready_zero_height_returns_none() {
+        let state = LayerShellHandshake::Ready {
             width: 1920,
             height: 0,
         };
-        assert_eq!(config.dimensions(), None);
+        assert_eq!(state.dimensions(), None);
     }
 
     #[test]
-    fn surface_config_ready_both_zero_returns_none() {
-        let config = SurfaceConfig::Ready {
+    fn layer_shell_handshake_ready_both_zero_returns_none() {
+        let state = LayerShellHandshake::Ready {
             width: 0,
             height: 0,
         };
-        assert_eq!(config.dimensions(), None);
+        assert_eq!(state.dimensions(), None);
+    }
+
+    #[test]
+    fn surface_role_to_layer_backdrop() {
+        assert_eq!(Layer::from(SurfaceRole::Backdrop), Layer::Top);
+    }
+
+    #[test]
+    fn surface_role_to_layer_overlay() {
+        assert_eq!(Layer::from(SurfaceRole::Overlay), Layer::Overlay);
+    }
+
+    #[test]
+    fn rgb_from_array() {
+        let rgb: Color = [255, 128, 0].into();
+        assert_eq!(rgb.r, 255);
+        assert_eq!(rgb.g, 128);
+        assert_eq!(rgb.b, 0);
+    }
+
+    #[test]
+    fn rgb_to_array() {
+        let arr: [u8; 3] = Color::new(10, 20, 30).into();
+        assert_eq!(arr, [10, 20, 30]);
+    }
+
+    #[test]
+    fn rgb_constants() {
+        assert_eq!(Color::BLACK, Color::new(0, 0, 0));
+        assert_eq!(Color::WHITE, Color::new(255, 255, 255));
+    }
+
+    #[test]
+    fn opacity_clamps_above() {
+        assert_eq!(Opacity::new(1.5).as_f64(), 1.0);
+    }
+
+    #[test]
+    fn opacity_clamps_below() {
+        assert_eq!(Opacity::new(-0.5).as_f64(), 0.0);
+    }
+
+    #[test]
+    fn opacity_as_u8_zero() {
+        assert_eq!(Opacity::new(0.0).as_u8(), 0);
+    }
+
+    #[test]
+    fn opacity_as_u8_one() {
+        assert_eq!(Opacity::new(1.0).as_u8(), 255);
+    }
+
+    #[test]
+    fn opacity_as_u8_half() {
+        assert_eq!(Opacity::new(0.5).as_u8(), 127);
+    }
+
+    #[test]
+    fn opacity_constants() {
+        assert_eq!(Opacity::TRANSPARENT.as_f64(), 0.0);
+        assert_eq!(Opacity::OPAQUE.as_f64(), 1.0);
     }
 
     #[test]
     fn premultiply_fully_opaque() {
-        assert_eq!(premultiply_argb(255, 128, 0, 255), 0xFF_FF_80_00);
+        assert_eq!(
+            premultiply_argb(Color::new(255, 128, 0), 255),
+            0xFF_FF_80_00
+        );
     }
 
     #[test]
     fn premultiply_fully_transparent() {
-        assert_eq!(premultiply_argb(255, 255, 255, 0), 0x00_00_00_00);
+        assert_eq!(premultiply_argb(Color::WHITE, 0), 0x00_00_00_00);
     }
 
     #[test]
     fn premultiply_half_alpha() {
-        let result = premultiply_argb(255, 0, 0, 128);
+        let result = premultiply_argb(Color::new(255, 0, 0), 128);
         let r = (result >> 16) & 0xFF;
         let a = (result >> 24) & 0xFF;
         assert_eq!(a, 128);
@@ -321,7 +604,7 @@ mod tests {
 
     #[test]
     fn premultiply_channel_order() {
-        let result = premultiply_argb(0xAA, 0xBB, 0xCC, 0xFF);
+        let result = premultiply_argb(Color::new(0xAA, 0xBB, 0xCC), 0xFF);
         assert_eq!(result, 0xFF_AA_BB_CC);
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -108,8 +108,10 @@ pub(crate) fn run(
 
     // Create DimController
     let dim = DimController::new(
-        config.target_opacity,
-        config.target_brightness,
+        config.target_opacity.as_f64(),
+        config
+            .target_brightness
+            .map(super::render::Brightness::as_f64),
         config.skip_active,
     );
 

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -75,8 +75,7 @@ use wayland_protocols_wlr::gamma_control::v1::client::zwlr_gamma_control_v1::{
 
 use crate::app::App;
 use crate::app::AppPhase;
-use crate::render::GammaState;
-use crate::render::SurfaceConfig;
+use crate::render::LayerShellHandshake;
 
 /// Wayland protocol state — all the compositor bindings.
 pub struct Wayland {
@@ -201,7 +200,7 @@ impl LayerShellHandler for App {
             .position(|s| s.layer.wl_surface() == layer.wl_surface());
 
         if let Some(idx) = idx {
-            self.surfaces[idx].config = SurfaceConfig::Ready {
+            self.surfaces[idx].configure = LayerShellHandshake::Ready {
                 width: configure.new_size.0,
                 height: configure.new_size.1,
             };
@@ -215,7 +214,7 @@ impl LayerShellHandler for App {
                 // In running state, draw based on dim state
                 if let Some(ref name) = output_name {
                     if let Some(update) = self.dim.current_update(name) {
-                        self.apply_output_update(name, update.alpha, update.brightness);
+                        self.apply_output_update(name, update.opacity, update.brightness);
                     }
                 }
             }
@@ -260,20 +259,16 @@ impl Dispatch<ZwlrGammaControlV1, usize> for App {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
+        let Some(surface) = state.surfaces.get_mut(*surface_idx) else {
+            return;
+        };
+
         match event {
             zwlr_gamma_control_v1::Event::GammaSize { size } => {
-                if let Some(surface) = state.surfaces.get_mut(*surface_idx) {
-                    if let GammaState::Pending(control) =
-                        std::mem::replace(&mut surface.gamma, GammaState::Unavailable)
-                    {
-                        surface.gamma = GammaState::Ready { control, size };
-                    }
-                }
+                surface.gamma.receive_size(size);
             }
             zwlr_gamma_control_v1::Event::Failed => {
-                if let Some(surface) = state.surfaces.get_mut(*surface_idx) {
-                    surface.gamma = GammaState::Unavailable;
-                }
+                surface.gamma.fail();
             }
             _ => {}
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -7,6 +7,9 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use crate::error::SpawnError;
+use crate::render::Brightness;
+use crate::render::Color;
+use crate::render::Opacity;
 use crate::run::run;
 
 /// Resolved configuration passed to the background thread.
@@ -26,12 +29,12 @@ pub(crate) struct Config {
     pub(crate) settle_delay: Option<Duration>,
     /// Duration of the initial fade-in animation.
     pub(crate) fade_duration: Option<Duration>,
-    /// Target alpha for dimmed overlays (0.0–1.0, already clamped).
-    pub(crate) target_opacity: f64,
-    /// RGB overlay color.
-    pub(crate) color: [u8; 3],
+    /// Target opacity for dimmed overlays.
+    pub(crate) target_opacity: Opacity,
+    /// Overlay color.
+    pub(crate) color: Color,
     /// Target brightness for gamma dimming. `None` means gamma is untouched.
-    pub(crate) target_brightness: Option<f64>,
+    pub(crate) target_brightness: Option<Brightness>,
 }
 
 /// Builder for configuring which outputs to dim.
@@ -41,9 +44,9 @@ pub struct ZenWindowBuilder {
     namespace: String,
     settle_delay: Option<Duration>,
     fade_duration: Option<Duration>,
-    opacity: f64,
-    color: [u8; 3],
-    brightness: Option<f64>,
+    opacity: Opacity,
+    color: Color,
+    brightness: Option<Brightness>,
 }
 
 /// Builder configuration and spawn methods.
@@ -55,8 +58,8 @@ impl ZenWindowBuilder {
             namespace: "wl-zenwindow".into(),
             settle_delay: None,
             fade_duration: None,
-            opacity: 1.0,
-            color: [0, 0, 0],
+            opacity: Opacity::OPAQUE,
+            color: Color::BLACK,
             brightness: None,
         }
     }
@@ -102,30 +105,64 @@ impl ZenWindowBuilder {
         self
     }
 
-    /// Set the overlay color as RGB (default: black `(0, 0, 0)`).
+    /// Set the overlay color (default: black).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl_zenwindow::{ZenWindow, Color};
+    ///
+    /// let _ = ZenWindow::builder().color(Color::new(255, 0, 0));
+    /// let _ = ZenWindow::builder().color([0x1a, 0x1a, 0x1a]);
+    /// let _ = ZenWindow::builder().color(Color::BLACK);
+    /// ```
     #[must_use]
-    pub fn color(mut self, r: u8, g: u8, b: u8) -> Self {
-        self.color = [r, g, b];
+    pub fn color(mut self, color: impl Into<Color>) -> Self {
+        self.color = color.into();
         self
     }
 
-    /// Set the final overlay opacity (0.0 = transparent, 1.0 = fully opaque).
-    /// Default: 1.0.
+    /// Set the final overlay opacity (default: fully opaque).
+    ///
+    /// Accepts [`Opacity`] or a raw `f64` (clamped to 0.0–1.0).
+    /// `0.0` = transparent, `1.0` = fully opaque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl_zenwindow::{ZenWindow, Opacity};
+    ///
+    /// // Using a raw f64
+    /// let _ = ZenWindow::builder().opacity(0.85);
+    ///
+    /// // Using Opacity directly
+    /// let _ = ZenWindow::builder().opacity(Opacity::new(0.85));
+    /// ```
     #[must_use]
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = opacity.clamp(0.0, 1.0);
+    pub fn opacity(mut self, opacity: impl Into<Opacity>) -> Self {
+        self.opacity = opacity.into();
         self
     }
 
     /// Dim monitor brightness via gamma control.
-    /// 0.0 = completely dark, 1.0 = normal brightness.
+    ///
+    /// `0.0` = completely dark, `1.0` = normal brightness.
     /// Default: unset (gamma untouched).
     ///
     /// Uses the `zwlr_gamma_control_v1` protocol. Falls back gracefully
     /// if another client (e.g., `wlsunset`) already controls gamma.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wl_zenwindow::{ZenWindow, Brightness};
+    ///
+    /// let _ = ZenWindow::builder().brightness(0.7);
+    /// let _ = ZenWindow::builder().brightness(Brightness::new(0.7));
+    /// ```
     #[must_use]
-    pub fn brightness(mut self, brightness: f64) -> Self {
-        self.brightness = Some(brightness.clamp(0.0, 1.0));
+    pub fn brightness(mut self, brightness: impl Into<Brightness>) -> Self {
+        self.brightness = Some(brightness.into());
         self
     }
 
@@ -264,39 +301,45 @@ mod tests {
         assert_eq!(b.namespace, "wl-zenwindow");
         assert!(b.settle_delay.is_none());
         assert!(b.fade_duration.is_none());
-        assert_eq!(b.opacity, 1.0);
-        assert_eq!(b.color, [0, 0, 0]);
+        assert_eq!(b.opacity, Opacity::OPAQUE);
+        assert_eq!(b.color, Color::BLACK);
         assert!(b.brightness.is_none());
     }
 
     #[test]
     fn opacity_clamped_above() {
         let b = ZenWindow::builder().opacity(1.5);
-        assert_eq!(b.opacity, 1.0);
+        assert_eq!(b.opacity.as_f64(), 1.0);
     }
 
     #[test]
     fn opacity_clamped_below() {
         let b = ZenWindow::builder().opacity(-0.5);
-        assert_eq!(b.opacity, 0.0);
+        assert_eq!(b.opacity.as_f64(), 0.0);
     }
 
     #[test]
     fn opacity_within_range() {
         let b = ZenWindow::builder().opacity(0.7);
-        assert!((b.opacity - 0.7).abs() < f64::EPSILON);
+        assert!((b.opacity.as_f64() - 0.7).abs() < f64::EPSILON);
     }
 
     #[test]
     fn brightness_clamped_above() {
         let b = ZenWindow::builder().brightness(2.0);
-        assert_eq!(b.brightness, Some(1.0));
+        assert_eq!(
+            b.brightness.map(super::super::render::Brightness::as_f64),
+            Some(1.0)
+        );
     }
 
     #[test]
     fn brightness_clamped_below() {
         let b = ZenWindow::builder().brightness(-1.0);
-        assert_eq!(b.brightness, Some(0.0));
+        assert_eq!(
+            b.brightness.map(super::super::render::Brightness::as_f64),
+            Some(0.0)
+        );
     }
 
     #[test]
@@ -314,7 +357,7 @@ mod tests {
         let b = ZenWindow::builder()
             .skip_active()
             .namespace("custom")
-            .color(255, 0, 128)
+            .color([255, 0, 128])
             .opacity(0.5)
             .brightness(0.3)
             .settle_delay(Duration::from_millis(200))
@@ -322,9 +365,12 @@ mod tests {
 
         assert!(b.skip_active);
         assert_eq!(b.namespace, "custom");
-        assert_eq!(b.color, [255, 0, 128]);
-        assert!((b.opacity - 0.5).abs() < f64::EPSILON);
-        assert_eq!(b.brightness, Some(0.3));
+        assert_eq!(b.color, Color::new(255, 0, 128));
+        assert!((b.opacity.as_f64() - 0.5).abs() < f64::EPSILON);
+        assert_eq!(
+            b.brightness.map(super::super::render::Brightness::as_f64),
+            Some(0.3)
+        );
         assert_eq!(b.settle_delay, Some(Duration::from_millis(200)));
         assert_eq!(b.fade_duration, Some(Duration::from_millis(500)));
     }
@@ -338,7 +384,7 @@ mod tests {
             .settle_delay(Duration::from_millis(100))
             .fade_in(Duration::from_secs(1))
             .opacity(0.8)
-            .color(10, 20, 30)
+            .color([10, 20, 30])
             .brightness(0.6);
 
         let config = Config::from(&b);
@@ -348,9 +394,14 @@ mod tests {
         assert_eq!(config.namespace, "test-ns");
         assert_eq!(config.settle_delay, Some(Duration::from_millis(100)));
         assert_eq!(config.fade_duration, Some(Duration::from_secs(1)));
-        assert!((config.target_opacity - 0.8).abs() < f64::EPSILON);
-        assert_eq!(config.color, [10, 20, 30]);
-        assert_eq!(config.target_brightness, Some(0.6));
+        assert!((config.target_opacity.as_f64() - 0.8).abs() < f64::EPSILON);
+        assert_eq!(config.color, Color::new(10, 20, 30));
+        assert_eq!(
+            config
+                .target_brightness
+                .map(super::super::render::Brightness::as_f64),
+            Some(0.6)
+        );
     }
 
     #[test]
@@ -363,8 +414,8 @@ mod tests {
         assert_eq!(config.namespace, "wl-zenwindow");
         assert!(config.settle_delay.is_none());
         assert!(config.fade_duration.is_none());
-        assert_eq!(config.target_opacity, 1.0);
-        assert_eq!(config.color, [0, 0, 0]);
+        assert_eq!(config.target_opacity.as_f64(), 1.0);
+        assert_eq!(config.color, Color::BLACK);
         assert!(config.target_brightness.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Refactors `render.rs` before the v0.1 crates.io release. Introduces domain types, consolidates scattered logic, and improves the public API.

## Changes

### Domain types
- **`Color`** — overlay color newtype with `BLACK`, `WHITE` constants
- **`Opacity`** — surface transparency (0.0–1.0, clamped) with `TRANSPARENT`, `OPAQUE` constants
- **`Brightness`** — monitor brightness via gamma (0.0–1.0, clamped) with `DARK`, `NORMAL` constants

All three are zero-cost abstractions exported from the crate root.

### Naming improvements
- `SurfaceConfig` → `LayerShellHandshake` (describes the Wayland protocol handshake)
- Added `From<SurfaceRole> for Layer` trait impl

### API consolidation
- `draw_surface()` → `Surface::draw()` method
- `update_gamma()` → `Surface::update_gamma()` method
- `GammaState::receive_size()` and `GammaState::fail()` methods for protocol transitions
- Simplified `Surface::draw()` by separating alpha modifier and viewporter concerns

### Builder updates
- `.color()` accepts `impl Into<Color>` — use `Color::BLACK` or `[0, 0, 0]`
- `.opacity()` accepts `impl Into<Opacity>` — use `0.85` or `Opacity::new(0.85)`
- `.brightness()` accepts `impl Into<Brightness>` — use `0.7` or `Brightness::new(0.7)`

## Testing

All 56 tests pass. Clippy clean.