### PR TITLE
fix: replace unsafe pixel buffer cast with bytemuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6796,6 +6796,7 @@ dependencies = [
 name = "wl-zenwindow"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "gpui",
  "libc",
  "smithay-client-toolkit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["wayland", "layer-shell", "overlay", "dim", "wlroots"]
 categories = ["os::linux-apis", "gui"]
 
 [dependencies]
+bytemuck = "1"
 libc = "0.2"
 smithay-client-toolkit = "0.20"
 thiserror = "2"

--- a/src/render.rs
+++ b/src/render.rs
@@ -413,9 +413,7 @@ impl Surface {
             .expect("failed to create buffer");
 
         let pixel = premultiply_argb(color, alpha);
-        let pixels: &mut [u32] = unsafe {
-            std::slice::from_raw_parts_mut(canvas.as_mut_ptr().cast::<u32>(), canvas.len() / 4)
-        };
+        let pixels: &mut [u32] = bytemuck::cast_slice_mut(canvas);
         pixels.fill(pixel);
 
         self.layer


### PR DESCRIPTION
Replace the `unsafe` block in `render.rs` that casts `&mut [u8]` to `&mut [u32]` with `bytemuck::cast_slice_mut`, which performs the same cast safely with runtime alignment and length checks.

## Changes

- Added `bytemuck = "1"` dependency
- Replaced `unsafe { std::slice::from_raw_parts_mut(...) }` with `bytemuck::cast_slice_mut(canvas)`

Closes #8