### PR TITLE
refactor: replace libc unsafe blocks with safe rustix wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6798,7 +6798,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "gpui",
- "libc",
+ "rustix 1.1.4",
  "smithay-client-toolkit",
  "thiserror 2.0.18",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["os::linux-apis", "gui"]
 
 [dependencies]
 bytemuck = "1"
-libc = "0.2"
+rustix = { version = "1", features = ["event", "fs"] }
 smithay-client-toolkit = "0.20"
 thiserror = "2"
 wayland-client = "0.31"

--- a/src/render.rs
+++ b/src/render.rs
@@ -41,7 +41,6 @@
 use std::io::Seek;
 use std::io::Write;
 use std::os::fd::AsFd;
-use std::os::fd::FromRawFd;
 
 use smithay_client_toolkit::shell::wlr_layer::Layer;
 use smithay_client_toolkit::shell::wlr_layer::LayerSurface;
@@ -446,13 +445,8 @@ fn premultiply_argb(color: Color, alpha: u8) -> u32 {
     clippy::cast_sign_loss            // Values are always positive
 )]
 fn create_gamma_ramp(size: u32, brightness: f64) -> std::io::Result<std::fs::File> {
-    let name = std::ffi::CString::new("wl-zenwindow-gamma").unwrap();
-    let raw_fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
-    if raw_fd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    let mut file = unsafe { std::fs::File::from_raw_fd(raw_fd) };
+    let fd = rustix::fs::memfd_create("wl-zenwindow-gamma", rustix::fs::MemfdFlags::CLOEXEC)?;
+    let mut file = std::fs::File::from(fd);
     let n = size as usize;
     let divisor = n.saturating_sub(1).max(1) as f64;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -45,14 +45,17 @@ where
 ///
 /// Returns `true` if the fd is readable, `false` on timeout or error.
 fn poll_wayland_fd(fd: std::os::unix::io::BorrowedFd<'_>, timeout_ms: i32) -> bool {
-    use std::os::unix::io::AsRawFd;
-    let mut pollfd = libc::pollfd {
-        fd: fd.as_raw_fd(),
-        events: libc::POLLIN,
-        revents: 0,
+    use rustix::event::poll;
+    use rustix::event::PollFd;
+    use rustix::event::PollFlags;
+    use rustix::time::Timespec;
+
+    let timeout = Timespec {
+        tv_sec: i64::from(timeout_ms) / 1000,
+        tv_nsec: (i64::from(timeout_ms) % 1000) * 1_000_000,
     };
-    let ret = unsafe { libc::poll(&raw mut pollfd, 1, timeout_ms) };
-    ret > 0
+    let mut fds = [PollFd::new(&fd, PollFlags::IN)];
+    poll(&mut fds, Some(&timeout)).unwrap_or(0) > 0
 }
 
 /// Entry point for the background thread that manages overlay surfaces.


### PR DESCRIPTION
Replace all remaining `unsafe` blocks that use raw `libc` FFI with safe wrappers from `rustix`, which is already compiled as a transitive dependency via smithay-client-toolkit.

## Changes

- **`render.rs`**: Replace `libc::memfd_create` + `File::from_raw_fd` with `rustix::fs::memfd_create` (returns `OwnedFd`, safe `File::from()` conversion)
- **`run.rs`**: Replace `libc::poll` with `rustix::event::poll`
- **`Cargo.toml`**: Add `rustix = { version = "1", features = ["event", "fs"] }`, remove `libc`

After this change (combined with #27), the project has **zero `unsafe` blocks**.

A deeper refactor to replace the manual poll loop with calloop's `WaylandSource` is tracked in #28.