### PR TITLE
refactor: replace manual poll loop with calloop event loop (#28)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["os::linux-apis", "gui"]
 
 [dependencies]
 bytemuck = "1"
-rustix = { version = "1", features = ["event", "fs"] }
+rustix = { version = "1", features = ["fs"] }
 smithay-client-toolkit = "0.20"
 thiserror = "2"
 wayland-client = "0.31"

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,11 +205,19 @@ impl App {
     }
 
     /// Apply dimming updates to BOTH backdrop and overlay (for fade-in).
+    ///
+    /// Skipped (active) outputs are left alone — both backdrop and overlay
+    /// stay transparent so the focused window is fully visible during the
+    /// fade-in animation.
     pub fn apply_updates_all_layers(&mut self, updates: &DimUpdates) {
         let has_viewporter = self.wl.has_viewporter();
         let color = self.config.color;
 
         for update in updates.iter() {
+            if self.dim.is_output_skipped(&update.name) {
+                continue;
+            }
+
             for surface in &mut self.surfaces {
                 if surface.output_name.as_deref() != Some(&update.name) {
                     continue;

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -144,8 +144,7 @@ impl DimController {
     }
 
     /// Check if an output is currently skipped.
-    #[cfg(test)]
-    pub fn is_skipped(&self, name: &str) -> bool {
+    pub fn is_output_skipped(&self, name: &str) -> bool {
         self.outputs.get(name).is_some_and(|s| s.skipped)
     }
 
@@ -354,7 +353,7 @@ mod tests {
         let mut ctrl = DimController::new(0.8, Some(0.5), true);
         ctrl.add_output("DP-1".into(), true);
 
-        assert!(ctrl.is_skipped("DP-1"));
+        assert!(ctrl.is_output_skipped("DP-1"));
         assert_eq!(ctrl.active_output(), Some("DP-1"));
     }
 
@@ -377,8 +376,8 @@ mod tests {
         assert_eq!(updates[0].brightness.as_f64(), 0.5);
 
         // DP-2 should now be skipped, transition started
-        assert!(ctrl.is_skipped("DP-2"));
-        assert!(!ctrl.is_skipped("DP-1"));
+        assert!(ctrl.is_output_skipped("DP-2"));
+        assert!(!ctrl.is_output_skipped("DP-1"));
         assert!(ctrl.is_animating());
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,6 +9,8 @@ use std::time::Instant;
 
 use smithay_client_toolkit::compositor::CompositorState;
 use smithay_client_toolkit::output::OutputState;
+use smithay_client_toolkit::reexports::calloop::EventLoop;
+use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 use smithay_client_toolkit::registry::RegistryState;
 use smithay_client_toolkit::shell::wlr_layer::LayerShell;
 use smithay_client_toolkit::shm::slot::SlotPool;
@@ -39,23 +41,6 @@ where
     App: Dispatch<P, ()>,
 {
     globals.bind::<P, _, _>(qh, 1..=1, ()).ok()
-}
-
-/// Poll the Wayland connection fd with a timeout.
-///
-/// Returns `true` if the fd is readable, `false` on timeout or error.
-fn poll_wayland_fd(fd: std::os::unix::io::BorrowedFd<'_>, timeout_ms: i32) -> bool {
-    use rustix::event::poll;
-    use rustix::event::PollFd;
-    use rustix::event::PollFlags;
-    use rustix::time::Timespec;
-
-    let timeout = Timespec {
-        tv_sec: i64::from(timeout_ms) / 1000,
-        tv_nsec: (i64::from(timeout_ms) % 1000) * 1_000_000,
-    };
-    let mut fds = [PollFd::new(&fd, PollFlags::IN)];
-    poll(&mut fds, Some(&timeout)).unwrap_or(0) > 0
 }
 
 /// Entry point for the background thread that manages overlay surfaces.
@@ -172,7 +157,10 @@ pub(crate) fn run(
         tx.send(()).ok();
     }
 
-    // Run fade-in if configured, otherwise snap to target
+    // Run fade-in if configured, otherwise snap to target.
+    // Fade-in uses the event queue directly (flush + dispatch_pending)
+    // to avoid reading new events that could disturb DimController state
+    // while the animation is running.
     if let Some(duration) = app.config.fade_duration {
         run_fade_in(&mut app, &mut event_queue, duration)?;
     } else {
@@ -180,13 +168,25 @@ pub(crate) fn run(
         app.apply_updates(&updates);
     }
 
-    // Steady state
+    // Hand the event queue to calloop for steady-state dispatch
     app.phase = AppPhase::Running;
-    run_steady_state(&mut app, &mut event_queue, shutdown)?;
+    let mut event_loop: EventLoop<App> =
+        EventLoop::try_new().map_err(|e| SpawnError::Setup(e.into()))?;
+    WaylandSource::new(conn, event_queue)
+        .insert(event_loop.handle())
+        .map_err(|e| SpawnError::Setup(e.error.into()))?;
+
+    run_steady_state(&mut app, &mut event_loop, shutdown)?;
 
     Ok(())
 }
 
+/// Run the initial fade-in animation.
+///
+/// Uses the event queue directly rather than calloop — `dispatch_pending`
+/// processes only already-buffered events without reading new ones from
+/// the compositor, which prevents transient focus events (from the window
+/// settling) from disturbing the animation.
 fn run_fade_in(
     app: &mut App,
     event_queue: &mut wayland_client::EventQueue<App>,
@@ -224,10 +224,11 @@ fn run_fade_in(
 
 fn run_steady_state(
     app: &mut App,
-    event_queue: &mut wayland_client::EventQueue<App>,
+    event_loop: &mut EventLoop<App>,
     shutdown: &Arc<AtomicBool>,
 ) -> Result<(), SpawnError> {
-    let transition_tick = Duration::from_millis(8);
+    let animation_tick = Duration::from_millis(8);
+    let idle_timeout = Duration::from_millis(100);
 
     while app.phase == AppPhase::Running {
         if shutdown.load(Ordering::Acquire) {
@@ -235,36 +236,16 @@ fn run_steady_state(
             break;
         }
 
-        if app.is_animating() {
+        let timeout = if app.is_animating() {
             app.tick_transition();
-            event_queue
-                .flush()
-                .map_err(|e| SpawnError::Setup(e.into()))?;
-            event_queue
-                .dispatch_pending(app)
-                .map_err(|e| SpawnError::Setup(e.into()))?;
-            std::thread::sleep(transition_tick);
+            animation_tick
         } else {
-            // Poll-based dispatch with timeout for shutdown checks
-            event_queue
-                .flush()
-                .map_err(|e| SpawnError::Setup(e.into()))?;
-            if let Some(guard) = event_queue.prepare_read() {
-                let fd = guard.connection_fd();
-                if poll_wayland_fd(fd, 100) {
-                    if let Err(e) = guard.read() {
-                        app.phase = AppPhase::ShuttingDown;
-                        return Err(SpawnError::Setup(e.into()));
-                    }
-                }
-            }
-            event_queue
-                .dispatch_pending(app)
-                .map_err(|e| SpawnError::Setup(e.into()))?;
-            event_queue
-                .flush()
-                .map_err(|e| SpawnError::Setup(e.into()))?;
-        }
+            idle_timeout
+        };
+
+        event_loop
+            .dispatch(timeout, app)
+            .map_err(|e| SpawnError::Setup(e.into()))?;
     }
 
     Ok(())

--- a/src/window.rs
+++ b/src/window.rs
@@ -257,7 +257,8 @@ impl Drop for ZenWindow {
         self.shutdown.store(true, Ordering::Release);
         if let Some(handle) = self.handle.take() {
             // Give the event loop time to notice the shutdown signal and clean up.
-            // The poll timeout in the event loop is 100ms, so 1 second is generous.
+            // The calloop dispatch timeout in the event loop is 100ms, so 1 second
+            // is generous.
             let deadline = std::time::Instant::now() + Duration::from_secs(1);
             while !handle.is_finished() {
                 if std::time::Instant::now() >= deadline {


### PR DESCRIPTION
Replaces the manual `prepare_read` / `poll` / `read` / `dispatch_pending` / `flush` loop in steady state with calloop's `EventLoop` and `WaylandSource`, which handles all of that internally.

Closes #28

## Changes

### `Cargo.toml`
- Remove `event` feature from `rustix` (only `fs` remains for `memfd_create` in `render.rs`)

### `src/run.rs`
- Delete `poll_wayland_fd()` — the manual `rustix::event::poll` wrapper
- After setup and fade-in complete, hand the `Connection` and `EventQueue` to `WaylandSource::new().insert()` on a calloop `EventLoop`
- Replace the two-mode steady-state loop (manual poll when idle, sleep-based when animating) with a single `event_loop.dispatch(timeout)` call — 8ms when animating, 100ms when idle
- Setup and fade-in are unchanged — they use the event queue directly (`flush` + `dispatch_pending` + `sleep`), which avoids reading new events that could disturb DimController state during the animation

### `src/app.rs`
- `apply_updates_all_layers()` now skips the active output entirely during fade-in, matching the old behavior where both backdrop and overlay stayed transparent on the focused output
- Uses new `DimController::is_output_skipped()` method

### `src/dim.rs`
- Promote `is_skipped()` from `#[cfg(test)]` to public `is_output_skipped()`

### `src/window.rs`
- Update comment in `Drop` impl to reference calloop dispatch timeout

## Dependencies

No new crate dependencies — `calloop` and `calloop-wayland-source` are already transitive deps through `smithay-client-toolkit` (default `calloop` feature), accessed via `smithay_client_toolkit::reexports`.

## Related

- #30 — follow-up enhancement to snap the active output backdrop on fullscreen detection