### PR TITLE
fix: avoid cloning revealing output name on every transition tick

### DIFF
--- a/src/dim.rs
+++ b/src/dim.rs
@@ -220,12 +220,11 @@ impl DimController {
         let mut updates = Vec::new();
 
         // Animate the revealing output: alpha goes target→0, brightness goes target→1
-        let revealing = transition.revealing.clone();
-        if let Some(state) = self.outputs.get_mut(&revealing) {
+        if let Some(state) = self.outputs.get_mut(&transition.revealing) {
             state.alpha = self.target_opacity * (1.0 - eased);
             state.brightness = self.target_brightness + (1.0 - self.target_brightness) * eased;
             updates.push(OutputUpdate {
-                name: revealing,
+                name: transition.revealing.clone(),
                 opacity: Opacity::new(state.alpha),
                 brightness: Brightness::new(state.brightness),
             });


### PR DESCRIPTION
Closes #10

## What changed

The issue reported that `transition.revealing` was cloned on every animation tick (~8ms during cross-fade). The clone existed to work around a borrow conflict: `&self.transition` (immutable) vs `self.outputs.get_mut()` (mutable).

Since `self.transition` and `self.outputs` are disjoint struct fields, Rust's borrow checker allows borrowing them independently. The fix removes the upfront `.clone()` and passes `&transition.revealing` directly to `HashMap::get_mut()`. A clone still happens when constructing the `OutputUpdate` return value (owned `String` required), but only inside the branch that produces an update — not unconditionally.

## Issue staleness notes

The issue referenced `transition.rs` and a "linear search by name" — both are outdated:

- The code now lives in `src/dim.rs` (not `transition.rs`)
- `self.outputs` is a `HashMap`, so lookup is O(1), not linear
- The proposed index-based fix doesn't apply to `HashMap` storage

The clone concern was still valid and is addressed here.