### PR TITLE
refactor: add App constructor and make fields private

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -61,20 +61,74 @@ pub enum AppPhase {
 /// The main application state — Wayland dispatch target.
 pub struct App {
     /// Wayland protocol bindings.
-    pub wl: Wayland,
+    wl: Wayland,
     /// Configuration.
-    pub config: Config,
+    config: Config,
     /// Managed surfaces.
-    pub surfaces: Vec<Surface>,
+    surfaces: Vec<Surface>,
     /// Tracked toplevels for focus detection.
-    pub(crate) toplevels: Vec<TrackedToplevel>,
+    toplevels: Vec<TrackedToplevel>,
     /// Current loop phase.
-    pub phase: AppPhase,
+    phase: AppPhase,
     /// Dimming state machine.
-    pub dim: DimController,
+    dim: DimController,
 }
 
 impl App {
+    /// Create a new `App` with the given Wayland bindings, config, phase, and
+    /// dim controller. Surfaces and toplevels start empty — they're populated
+    /// during setup via protocol roundtrips and [`create_surfaces`](Self::create_surfaces).
+    pub fn new(wl: Wayland, config: Config, phase: AppPhase, dim: DimController) -> Self {
+        Self {
+            wl,
+            config,
+            surfaces: Vec::new(),
+            toplevels: Vec::new(),
+            phase,
+            dim,
+        }
+    }
+
+    /// Configuration (read-only).
+    pub(crate) fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Current loop phase.
+    pub(crate) fn phase(&self) -> AppPhase {
+        self.phase
+    }
+
+    /// Set the loop phase.
+    pub(crate) fn set_phase(&mut self, phase: AppPhase) {
+        self.phase = phase;
+    }
+
+    /// Wayland protocol bindings (mutable).
+    pub(crate) fn wl_mut(&mut self) -> &mut Wayland {
+        &mut self.wl
+    }
+
+    /// Managed surfaces (read-only).
+    pub(crate) fn surfaces(&self) -> &[Surface] {
+        &self.surfaces
+    }
+
+    /// Managed surfaces (mutable).
+    pub(crate) fn surfaces_mut(&mut self) -> &mut Vec<Surface> {
+        &mut self.surfaces
+    }
+
+    /// Dimming state machine (read-only).
+    pub(crate) fn dim(&self) -> &DimController {
+        &self.dim
+    }
+
+    /// Dimming state machine (mutable).
+    pub(crate) fn dim_mut(&mut self) -> &mut DimController {
+        &mut self.dim
+    }
+
     /// Create surfaces for all outputs.
     pub fn create_surfaces(&mut self, qh: &QueueHandle<Self>) {
         let outputs: Vec<_> = self.wl.output_state.outputs().collect();

--- a/src/run.rs
+++ b/src/run.rs
@@ -122,14 +122,7 @@ pub(crate) fn run(
         toplevel_manager,
     };
 
-    let mut app = App {
-        wl,
-        config: config.clone(),
-        surfaces: Vec::new(),
-        toplevels: Vec::new(),
-        phase,
-        dim,
-    };
+    let mut app = App::new(wl, config.clone(), phase, dim);
 
     // Discover outputs and toplevels
     event_queue
@@ -161,15 +154,15 @@ pub(crate) fn run(
     // Fade-in uses the event queue directly (flush + dispatch_pending)
     // to avoid reading new events that could disturb DimController state
     // while the animation is running.
-    if let Some(duration) = app.config.fade_duration {
+    if let Some(duration) = app.config().fade_duration {
         run_fade_in(&mut app, &mut event_queue, duration)?;
     } else {
-        let updates = app.dim.snap_to_target();
+        let updates = app.dim_mut().snap_to_target();
         app.apply_updates(&updates);
     }
 
     // Hand the event queue to calloop for steady-state dispatch
-    app.phase = AppPhase::Running;
+    app.set_phase(AppPhase::Running);
     let mut event_loop: EventLoop<App> =
         EventLoop::try_new().map_err(|e| SpawnError::Setup(e.into()))?;
     WaylandSource::new(conn, event_queue)
@@ -197,7 +190,7 @@ fn run_fade_in(
 
     loop {
         let elapsed = start.elapsed();
-        let updates = app.dim.fade_in_frame(elapsed, duration);
+        let updates = app.dim_mut().fade_in_frame(elapsed, duration);
         // During fade-in, animate BOTH backdrop and overlay together
         app.apply_updates_all_layers(&updates);
 
@@ -230,9 +223,9 @@ fn run_steady_state(
     let animation_tick = Duration::from_millis(8);
     let idle_timeout = Duration::from_millis(100);
 
-    while app.phase == AppPhase::Running {
+    while app.phase() == AppPhase::Running {
         if shutdown.load(Ordering::Acquire) {
-            app.phase = AppPhase::ShuttingDown;
+            app.set_phase(AppPhase::ShuttingDown);
             break;
         }
 

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -212,7 +212,7 @@ impl CompositorHandler for App {
 
 impl OutputHandler for App {
     fn output_state(&mut self) -> &mut OutputState {
-        &mut self.wl.output_state
+        &mut self.wl_mut().output_state
     }
 
     fn new_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_output::WlOutput) {}
@@ -242,25 +242,25 @@ impl LayerShellHandler for App {
         _serial: u32,
     ) {
         let idx = self
-            .surfaces
+            .surfaces()
             .iter()
             .position(|s| s.layer.wl_surface() == layer.wl_surface());
 
         if let Some(idx) = idx {
-            self.surfaces[idx].configure = LayerShellHandshake::Ready {
+            self.surfaces_mut()[idx].configure = LayerShellHandshake::Ready {
                 width: configure.new_size.0,
                 height: configure.new_size.1,
             };
 
-            let output_name = self.surfaces[idx].output_name.clone();
+            let output_name = self.surfaces()[idx].output_name.clone();
 
-            if self.phase == AppPhase::FadingIn {
+            if self.phase() == AppPhase::FadingIn {
                 // During fade-in, both backdrops and overlays start transparent
                 // The fade loop will animate them together
             } else {
                 // In running state, draw based on dim state
                 if let Some(ref name) = output_name {
-                    if let Some(update) = self.dim.current_update(name) {
+                    if let Some(update) = self.dim().current_update(name) {
                         self.apply_output_update(name, update.opacity, update.brightness);
                     }
                 }
@@ -271,13 +271,13 @@ impl LayerShellHandler for App {
 
 impl ShmHandler for App {
     fn shm_state(&mut self) -> &mut Shm {
-        &mut self.wl.shm
+        &mut self.wl_mut().shm
     }
 }
 
 impl ProvidesRegistryState for App {
     fn registry(&mut self) -> &mut RegistryState {
-        &mut self.wl.registry
+        &mut self.wl_mut().registry
     }
 
     registry_handlers!(OutputState);
@@ -306,7 +306,7 @@ impl Dispatch<ZwlrGammaControlV1, usize> for App {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        let Some(surface) = state.surfaces.get_mut(*surface_idx) else {
+        let Some(surface) = state.surfaces_mut().get_mut(*surface_idx) else {
             return;
         };
 
@@ -334,7 +334,7 @@ impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for App {
         _qh: &QueueHandle<Self>,
     ) {
         if let zwlr_foreign_toplevel_manager_v1::Event::Finished = event {
-            state.wl.toplevel_manager = None;
+            state.wl_mut().toplevel_manager = None;
         }
     }
 
@@ -360,7 +360,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for App {
                 {
                     // Activated window is moving! Snap ALL overlays opaque immediately.
                     state.dim_all_outputs();
-                    state.dim.cancel_transition();
+                    state.dim_mut().cancel_transition();
                 }
 
                 state.find_or_insert_toplevel(proxy).enter_output(output);
@@ -372,7 +372,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for App {
                 {
                     // Activated window is leaving an output! Snap ALL overlays opaque.
                     state.dim_all_outputs();
-                    state.dim.cancel_transition();
+                    state.dim_mut().cancel_transition();
                 }
 
                 state.find_or_insert_toplevel(proxy).leave_output();


### PR DESCRIPTION
Closes #34

Add `App::new(wl, config, phase, dim)` constructor so `surfaces` and `toplevels` (which always start empty) are encapsulated. All fields are now private with `pub(crate)` accessors where needed:

- `config()` — read-only config access
- `phase()` / `set_phase()` — loop phase read/write
- `wl_mut()` — mutable Wayland bindings (for smithay trait impls)
- `surfaces()` / `surfaces_mut()` — surface list access
- `dim()` / `dim_mut()` — dimming state machine access

Updated `run.rs` to use the constructor and accessors, and `wayland.rs` trait impls to go through accessors instead of direct field access.