### PR TITLE
feat: add spawn_with for choreographed launches, remove skip_active

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Works with any compositor that supports `wlr-layer-shell`: Sway, Hyprland, Niri,
 
 - Tracks the focused window and keeps its monitor undimmed
 - Cross-fades overlays when focus moves between monitors
+- Choreographed launch mode: fade to black, launch an app, reveal it
 - Optionally dims monitor brightness via gamma control (falls back if another client like wlsunset already has it)
 - Configurable overlay color, opacity, fade duration, and settle delay
 - Dropping the handle removes overlays and restores gamma
@@ -32,35 +33,18 @@ See the [API documentation](https://docs.rs/wl-zenwindow) for the full builder A
 
 ## Getting started
 
-The simplest thing you can do is put a black overlay on every monitor:
+The simplest usage dims all monitors except the one with the focused window:
 
 ```rust
 use wl_zenwindow::ZenWindow;
 
-fn main() {
-    let _zen = ZenWindow::builder()
-        .spawn()
-        .expect("failed to start overlays");
-
-    // Overlays stay up as long as `_zen` is alive.
-    // Park the thread so the program doesn't exit immediately.
-    std::thread::park();
-}
-```
-
-`spawn()` connects to Wayland, creates overlay surfaces on each output, and returns a handle. The overlays live as long as the handle does — drop it and they disappear.
-
-Dimming *all* monitors isn't very useful though. Add `skip_active()` to leave the monitor with the focused window clear, and `opacity()` to make the overlays translucent so you can still see what's behind them:
-
-```rust
 let _zen = ZenWindow::builder()
-    .skip_active()
     .opacity(0.85)
     .spawn()
     .expect("failed to start overlays");
 ```
 
-Now when you move focus to a different monitor, the overlay follows — the old monitor dims and the new one clears.
+`spawn()` connects to Wayland, creates overlay surfaces on each output, and returns a handle. Focus tracking is automatic — when you move focus to a different monitor, the overlay follows. The overlays live as long as the handle does; drop it and they disappear.
 
 Overlays only darken the visual — the backlight stays at full brightness. If your compositor supports `zwlr_gamma_control_v1`, add `brightness()` to dim the actual monitor brightness too. And `fade_in()` keeps the overlays from snapping on instantly:
 
@@ -68,7 +52,6 @@ Overlays only darken the visual — the backlight stays at full brightness. If y
 use std::time::Duration;
 
 let _zen = ZenWindow::builder()
-    .skip_active()
     .opacity(0.85)
     .brightness(0.7)
     .fade_in(Duration::from_millis(500))
@@ -88,9 +71,28 @@ Or just let it go out of scope. There's no explicit cleanup API to call.
 
 ## Usage
 
+### Choreographed launch
+
+Use `spawn_with()` to launch an application with a cinematic entrance. The library fades all outputs to target opacity, calls your callback (the app launches behind the opaque overlays), then reveals the output where the new window appears:
+
+```rust
+use std::process::Command;
+use std::time::Duration;
+
+let _zen = ZenWindow::builder()
+    .opacity(0.85)
+    .fade_in(Duration::from_millis(300))
+    .spawn_with(|| {
+        Command::new("my-fullscreen-app").spawn().unwrap();
+    })
+    .expect("failed to start overlays");
+```
+
+The user sees: desktop → smooth fade to dark → smooth reveal of the settled window. After the reveal, focus tracking is active — the focused output stays undimmed while others remain dimmed.
+
 ### Dimming only specific monitors
 
-If you want to always dim certain monitors regardless of focus, use `skip_output()` to exclude them by their Wayland name:
+If you want to always leave certain monitors undimmed regardless of focus, use `skip_output()` to exclude them by their Wayland name:
 
 ```rust
 // Only dim DP-2 and HDMI-1; leave DP-1 and eDP-1 alone
@@ -103,16 +105,6 @@ let _zen = ZenWindow::builder()
 
 You can find your output names with `swaymsg -t get_outputs`, `hyprctl monitors`, or `wlr-randr`.
 
-Combine `skip_output()` with `skip_active()` to dim everything except specific monitors *and* the focused one:
-
-```rust
-let _zen = ZenWindow::builder()
-    .skip_output("eDP-1") // never dim the laptop screen
-    .skip_active()         // also skip whichever monitor has focus
-    .spawn()
-    .expect("failed to start overlays");
-```
-
 ### Handling errors
 
 `spawn()` returns a `Result<ZenWindow, SpawnError>`. If you want to fall back gracefully instead of crashing:
@@ -120,7 +112,7 @@ let _zen = ZenWindow::builder()
 ```rust
 use wl_zenwindow::{ZenWindow, SpawnError};
 
-let zen = match ZenWindow::builder().skip_active().spawn() {
+let zen = match ZenWindow::builder().spawn() {
     Ok(handle) => Some(handle),
     Err(SpawnError::WaylandConnection(_)) => {
         eprintln!("not running on Wayland, skipping overlays");
@@ -141,7 +133,6 @@ If you don't care about errors at all, `spawn_nonblocking()` returns a handle di
 
 ```rust
 let _zen = ZenWindow::builder()
-    .skip_active()
     .spawn_nonblocking();
 ```
 
@@ -153,7 +144,6 @@ When launching overlays alongside a UI window, the window needs time to appear a
 use std::time::Duration;
 
 let _zen = ZenWindow::builder()
-    .skip_active()
     .settle_delay(Duration::from_millis(200))
     .fade_in(Duration::from_millis(500))
     .spawn_nonblocking();
@@ -176,7 +166,6 @@ If you see the wrong monitor dim briefly on startup, increase the settle delay. 
 use std::time::Duration;
 
 let _zen = ZenWindow::builder()
-    .skip_active()
     .settle_delay(Duration::from_millis(300)) // wait for window to settle
     .fade_in(Duration::from_millis(400))      // smooth fade-in
     .spawn()

--- a/examples/gpui/main.rs
+++ b/examples/gpui/main.rs
@@ -70,7 +70,6 @@ fn main() {
             |_window, cx| {
                 let zen = wl_zenwindow::ZenWindow::builder()
                     .namespace("wl-zenwindow-demo")
-                    .skip_active()
                     .settle_delay(std::time::Duration::from_millis(200))
                     .fade_in(std::time::Duration::from_millis(500))
                     .spawn_nonblocking();

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,8 @@
 //!
 //! - **`FadingIn`** — Initial animation. Both backdrops and overlays animate
 //!   from transparent to target together.
+//! - **`WaitingForReveal`** — After a `spawn_with` callback. Polls for a new
+//!   fullscreen toplevel (or timeout) before revealing the active output.
 //! - **`Running`** — Steady state. Only overlays participate in focus
 //!   transitions; backdrops stay at target opacity as a safety net.
 //! - **`ShuttingDown`** — Cleanup.
@@ -26,13 +28,17 @@
 //!
 //! This separation keeps dimming logic testable without Wayland.
 
+use std::time::Instant;
+
 use smithay_client_toolkit::shell::wlr_layer::Anchor;
 use smithay_client_toolkit::shell::wlr_layer::KeyboardInteractivity;
 use smithay_client_toolkit::shell::wlr_layer::LayerSurface;
 use smithay_client_toolkit::shell::WaylandSurface;
+use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::Proxy as _;
 use wayland_client::QueueHandle;
+use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_handle_v1::State as ToplevelState;
 use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_handle_v1::ZwlrForeignToplevelHandleV1;
 
 use crate::dim::DimController;
@@ -46,16 +52,32 @@ use crate::render::SurfaceRole;
 use crate::wayland::TrackedToplevel;
 use crate::wayland::Wayland;
 use crate::window::Config;
+use crate::window::SpawnMode;
 
 /// Which phase of the event loop we're in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppPhase {
     /// Initial fade-in animation.
     FadingIn,
+    /// Waiting for a new toplevel to appear after a `spawn_with` callback.
+    WaitingForReveal,
     /// Steady state — overlays are up, handling focus transitions.
     Running,
     /// Shutting down.
     ShuttingDown,
+}
+
+/// Timeout before revealing regardless of toplevel state.
+const REVEAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// State for the `spawn_with` reveal sequence.
+struct RevealState {
+    /// Toplevel IDs that existed before the callback was called.
+    /// A Vec rather than `HashSet` because `ObjectId` has interior mutability
+    /// (`AtomicBool` for lifecycle tracking) and the toplevel count is tiny.
+    snapshot: Vec<ObjectId>,
+    /// Deadline after which we reveal regardless of toplevel state.
+    deadline: Instant,
 }
 
 /// The main application state — Wayland dispatch target.
@@ -72,6 +94,8 @@ pub struct App {
     phase: AppPhase,
     /// Dimming state machine.
     dim: DimController,
+    /// State for `spawn_with` reveal sequencing.
+    reveal: Option<RevealState>,
 }
 
 impl App {
@@ -86,6 +110,7 @@ impl App {
             toplevels: Vec::new(),
             phase,
             dim,
+            reveal: None,
         }
     }
 
@@ -148,9 +173,13 @@ impl App {
             self.create_surface(&output, output_name.clone(), SurfaceRole::Backdrop, qh);
             self.create_surface(&output, output_name.clone(), SurfaceRole::Overlay, qh);
 
-            // Register with DimController
+            // Register with DimController.
+            // For SpawnWith, no output is skipped during fade-in — everything
+            // fades to opaque so the callback's window launches behind it.
+            // The reveal will set the active output afterward.
             if let Some(ref name) = output_name {
-                let is_active = self.dim.active_output() == Some(name.as_str());
+                let is_active = self.config.spawn_mode == SpawnMode::Standard
+                    && self.dim.active_output() == Some(name.as_str());
                 self.dim.add_output(name.clone(), is_active);
             }
         }
@@ -372,6 +401,74 @@ impl App {
     pub fn tick_transition(&mut self) {
         let updates = self.dim.tick();
         self.apply_updates(&updates);
+    }
+
+    /// Snapshot current toplevels and start waiting for a new one to appear.
+    pub fn begin_waiting_for_reveal(&mut self) {
+        let snapshot = self
+            .toplevels
+            .iter()
+            .map(super::wayland::TrackedToplevel::handle_id)
+            .collect();
+        self.reveal = Some(RevealState {
+            snapshot,
+            deadline: Instant::now() + REVEAL_TIMEOUT,
+        });
+        self.phase = AppPhase::WaitingForReveal;
+    }
+
+    /// Check if the reveal should trigger and do it if so.
+    ///
+    /// Returns `true` if the reveal was triggered (phase transitions to Running).
+    pub fn check_reveal(&mut self) -> bool {
+        let Some(reveal) = &self.reveal else {
+            return false;
+        };
+
+        // Happy path: new toplevel with fullscreen state
+        let new_fullscreen_output = self
+            .toplevels
+            .iter()
+            .filter(|t| !reveal.snapshot.iter().any(|id| *id == t.handle_id()))
+            .find(|t| t.has_state(ToplevelState::Fullscreen))
+            .and_then(|t| t.output())
+            .and_then(|output| self.wl.output_state.info(output))
+            .and_then(|info| info.name.clone());
+
+        if let Some(name) = new_fullscreen_output {
+            self.trigger_reveal(&name);
+            return true;
+        }
+
+        // Timeout fallback: reveal whatever output is active
+        if Instant::now() >= reveal.deadline {
+            // Try new toplevel's output first, then active output
+            let output = self
+                .toplevels
+                .iter()
+                .filter(|t| !reveal.snapshot.iter().any(|id| *id == t.handle_id()))
+                .find_map(|t| t.output())
+                .and_then(|output| self.wl.output_state.info(output))
+                .and_then(|info| info.name.clone())
+                .or_else(|| self.active_output_name());
+
+            if let Some(name) = output {
+                self.trigger_reveal(&name);
+            } else {
+                // No output to reveal — just go to running state
+                self.reveal = None;
+                self.phase = AppPhase::Running;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    fn trigger_reveal(&mut self, output_name: &str) {
+        self.dim.reveal_output(output_name);
+        self.reveal = None;
+        self.phase = AppPhase::Running;
     }
 
     /// Immediately dim ALL outputs (snap all overlays to opaque).

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -25,6 +25,7 @@
 //!
 //! - [`fade_in_frame`] — startup animation, all outputs together
 //! - [`tick`] — cross-fade on the revealing output only
+//! - [`reveal_output`] — choreographed reveal after `spawn_with` callback
 //! - [`snap_to_target`] — instant jump, no animation
 //! - [`snap_all_to_dimmed`] — emergency snap during window drag
 
@@ -71,7 +72,6 @@ pub struct OutputUpdate {
 pub struct DimController {
     target_opacity: f64,
     target_brightness: f64,
-    skip_active: bool,
 
     /// Per-output dimming state
     outputs: HashMap<String, OutputDimState>,
@@ -92,20 +92,18 @@ struct Transition {
 }
 
 impl DimController {
-    pub fn new(target_opacity: f64, target_brightness: Option<f64>, skip_active: bool) -> Self {
+    pub fn new(target_opacity: f64, target_brightness: Option<f64>) -> Self {
         Self {
             target_opacity,
             target_brightness: target_brightness.unwrap_or(1.0),
-            skip_active,
             outputs: HashMap::new(),
             active: None,
             transition: None,
         }
     }
 
-    /// Register an output. Starts at target dimming unless it's the active output.
+    /// Register an output. Active outputs are skipped (left undimmed).
     pub fn add_output(&mut self, name: String, is_active: bool) {
-        let skipped = self.skip_active && is_active;
         if is_active {
             self.active = Some(name.clone());
         }
@@ -116,7 +114,7 @@ impl DimController {
                 // and 1.0 brightness (normal gamma). The fade-in will animate them.
                 alpha: 0.0,
                 brightness: 1.0,
-                skipped,
+                skipped: is_active,
             },
         );
     }
@@ -155,9 +153,6 @@ impl DimController {
 
     /// Focus changed to a new output. Returns immediate updates and starts transition.
     pub fn focus_changed(&mut self, new_active: Option<String>) -> DimUpdates {
-        if !self.skip_active {
-            return DimUpdates::default();
-        }
         if self.active == new_active {
             return DimUpdates::default();
         }
@@ -307,6 +302,24 @@ impl DimController {
         self.transition = None;
     }
 
+    /// Reveal a specific output after a choreographed launch.
+    ///
+    /// Marks the output as the active (skipped) output and starts a
+    /// transition to fade its overlay from target opacity to transparent.
+    /// After the reveal animation completes, normal focus tracking takes over.
+    pub fn reveal_output(&mut self, name: &str) {
+        self.active = Some(name.to_string());
+        if let Some(state) = self.outputs.get_mut(name) {
+            state.skipped = true;
+        }
+        self.transition = Some(Transition {
+            start: Instant::now(),
+            delay: Duration::from_millis(50),
+            duration: Duration::from_millis(200),
+            revealing: name.to_string(),
+        });
+    }
+
     /// Snap ALL outputs to dimmed state (overlays opaque).
     /// Used during window movement to prevent flash.
     pub fn snap_all_to_dimmed(&mut self) -> DimUpdates {
@@ -338,7 +351,7 @@ mod tests {
 
     #[test]
     fn new_output_starts_at_zero_alpha() {
-        let mut ctrl = DimController::new(0.8, Some(0.5), true);
+        let mut ctrl = DimController::new(0.8, Some(0.5));
         ctrl.add_output("DP-1".into(), false);
 
         let state = ctrl.get("DP-1").unwrap();
@@ -349,7 +362,7 @@ mod tests {
 
     #[test]
     fn active_output_is_skipped() {
-        let mut ctrl = DimController::new(0.8, Some(0.5), true);
+        let mut ctrl = DimController::new(0.8, Some(0.5));
         ctrl.add_output("DP-1".into(), true);
 
         assert!(ctrl.is_output_skipped("DP-1"));
@@ -358,7 +371,7 @@ mod tests {
 
     #[test]
     fn focus_change_dims_old_reveals_new() {
-        let mut ctrl = DimController::new(0.8, Some(0.5), true);
+        let mut ctrl = DimController::new(0.8, Some(0.5));
         ctrl.add_output("DP-1".into(), true);
         ctrl.add_output("DP-2".into(), false);
 
@@ -382,7 +395,7 @@ mod tests {
 
     #[test]
     fn tick_animates_revealing_output() {
-        let mut ctrl = DimController::new(1.0, Some(0.5), true);
+        let mut ctrl = DimController::new(1.0, Some(0.5));
         ctrl.add_output("DP-1".into(), true);
         ctrl.add_output("DP-2".into(), false);
 
@@ -410,7 +423,7 @@ mod tests {
 
     #[test]
     fn fade_in_frame_respects_skipped() {
-        let mut ctrl = DimController::new(0.8, Some(0.5), true);
+        let mut ctrl = DimController::new(0.8, Some(0.5));
         ctrl.add_output("DP-1".into(), true); // active, skipped
         ctrl.add_output("DP-2".into(), false); // not skipped
 
@@ -430,7 +443,7 @@ mod tests {
 
     #[test]
     fn remove_output_clears_transition() {
-        let mut ctrl = DimController::new(1.0, Some(0.5), true);
+        let mut ctrl = DimController::new(1.0, Some(0.5));
         ctrl.add_output("DP-1".into(), true);
         ctrl.add_output("DP-2".into(), false);
 
@@ -450,7 +463,7 @@ mod tests {
 
     #[test]
     fn snap_to_target_sets_final_values() {
-        let mut ctrl = DimController::new(0.8, Some(0.4), true);
+        let mut ctrl = DimController::new(0.8, Some(0.4));
         ctrl.add_output("DP-1".into(), true);
         ctrl.add_output("DP-2".into(), false);
 
@@ -463,5 +476,24 @@ mod tests {
         assert_eq!(dp1.brightness.as_f64(), 1.0);
         assert_eq!(dp2.opacity.as_f64(), 0.8);
         assert_eq!(dp2.brightness.as_f64(), 0.4);
+    }
+
+    #[test]
+    fn reveal_output_starts_transition() {
+        let mut ctrl = DimController::new(0.8, Some(0.5));
+        ctrl.add_output("DP-1".into(), false);
+        ctrl.add_output("DP-2".into(), false);
+
+        // Simulate post-fade-in state: both at target
+        ctrl.outputs.get_mut("DP-1").unwrap().alpha = 0.8;
+        ctrl.outputs.get_mut("DP-1").unwrap().brightness = 0.5;
+        ctrl.outputs.get_mut("DP-2").unwrap().alpha = 0.8;
+        ctrl.outputs.get_mut("DP-2").unwrap().brightness = 0.5;
+
+        ctrl.reveal_output("DP-1");
+
+        assert!(ctrl.is_animating());
+        assert!(ctrl.is_output_skipped("DP-1"));
+        assert_eq!(ctrl.active_output(), Some("DP-1"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 //!
 //! // Dim all monitors except the one with the focused window
 //! let zen = ZenWindow::builder()
-//!     .skip_active()
 //!     .opacity(0.85)
 //!     .fade_in(Duration::from_millis(500))
 //!     .spawn()
@@ -22,6 +21,26 @@
 //! // Overlays stay up as long as the handle is alive
 //! // Dropping it removes overlays and restores gamma
 //! drop(zen);
+//! ```
+//!
+//! # Choreographed launch
+//!
+//! Use [`spawn_with()`](ZenWindowBuilder::spawn_with) to own the sequencing
+//! when launching an application. The library fades all outputs to target
+//! opacity, calls your callback, then reveals the output where the new
+//! window appears.
+//!
+//! ```no_run
+//! # use wl_zenwindow::ZenWindow;
+//! # use std::time::Duration;
+//! # use std::process::Command;
+//! let zen = ZenWindow::builder()
+//!     .opacity(0.85)
+//!     .fade_in(Duration::from_millis(300))
+//!     .spawn_with(|| {
+//!         Command::new("my-fullscreen-app").spawn().unwrap();
+//!     })
+//!     .expect("failed to start zen overlays");
 //! ```
 //!
 //! # Non-blocking spawn
@@ -34,7 +53,6 @@
 //! # use wl_zenwindow::ZenWindow;
 //! # use std::time::Duration;
 //! let _zen = ZenWindow::builder()
-//!     .skip_active()
 //!     .settle_delay(Duration::from_millis(100))
 //!     .fade_in(Duration::from_millis(500))
 //!     .spawn_nonblocking();
@@ -48,7 +66,7 @@
 //! ```no_run
 //! use wl_zenwindow::{ZenWindow, SpawnError};
 //!
-//! let zen = match ZenWindow::builder().skip_active().spawn() {
+//! let zen = match ZenWindow::builder().spawn() {
 //!     Ok(handle) => Some(handle),
 //!     Err(SpawnError::WaylandConnection(_)) => {
 //!         eprintln!("not running on Wayland, skipping overlays");
@@ -68,8 +86,10 @@
 //! # Configuration
 //!
 //! All configuration is done through [`ZenWindowBuilder`]. Every setting has a
-//! sensible default — the only required call is [`spawn()`](ZenWindowBuilder::spawn)
-//! or [`spawn_nonblocking()`](ZenWindowBuilder::spawn_nonblocking).
+//! sensible default — the only required call is one of
+//! [`spawn()`](ZenWindowBuilder::spawn),
+//! [`spawn_with()`](ZenWindowBuilder::spawn_with), or
+//! [`spawn_nonblocking()`](ZenWindowBuilder::spawn_nonblocking).
 //!
 //! | Method | Default | Range | Description |
 //! |--------|---------|-------|-------------|
@@ -78,7 +98,6 @@
 //! | [`color()`](ZenWindowBuilder::color) | `(0, 0, 0)` | RGB `u8` triplet | Overlay color. |
 //! | [`fade_in()`](ZenWindowBuilder::fade_in) | `None` | `Duration` | Fade-in duration (ease-out curve). `None` = instant. |
 //! | [`settle_delay()`](ZenWindowBuilder::settle_delay) | `None` | `Duration` | Delay before creating surfaces. Runs on the background thread. |
-//! | [`skip_active()`](ZenWindowBuilder::skip_active) | `false` | — | Leave the focused monitor undimmed. |
 //! | [`skip_output()`](ZenWindowBuilder::skip_output) | empty | — | Skip specific outputs by Wayland name (e.g. `"DP-1"`). |
 //! | [`namespace()`](ZenWindowBuilder::namespace) | `"wl-zenwindow"` | string | Layer-shell namespace for the overlay surfaces. |
 //!
@@ -118,15 +137,14 @@
 //!
 //! ## Focus tracking
 //!
-//! When [`skip_active()`](ZenWindowBuilder::skip_active) is enabled, the
-//! library binds `zwlr_foreign_toplevel_manager_v1` and watches for activated
-//! toplevel events. Each toplevel reports which output it's on. When the
-//! activated toplevel changes outputs, the library cross-fades: the overlay
-//! on the newly active output fades out while the previously active output
-//! returns to its dimmed state.
+//! The library automatically binds `zwlr_foreign_toplevel_manager_v1` and
+//! watches for activated toplevel events. Each toplevel reports which output
+//! it's on. When the activated toplevel changes outputs, the library
+//! cross-fades: the overlay on the newly active output fades out while the
+//! previously active output returns to its dimmed state.
 //!
 //! If the protocol isn't available (e.g., on compositors that don't implement
-//! it), `skip_active()` has no effect and all non-skipped outputs are dimmed.
+//! it), all non-skipped outputs are dimmed uniformly.
 //!
 //! ## Gamma control contention
 //!

--- a/src/run.rs
+++ b/src/run.rs
@@ -56,6 +56,7 @@ pub(crate) fn run(
     config: &Config,
     ready_tx: Option<mpsc::Sender<()>>,
     shutdown: &Arc<AtomicBool>,
+    spawn_callback: Option<Box<dyn FnOnce() + Send>>,
 ) -> Result<(), SpawnError> {
     if let Some(delay) = config.settle_delay {
         std::thread::sleep(delay);
@@ -88,11 +89,7 @@ pub(crate) fn run(
     let viewporter: Option<WpViewporter> = try_bind(&globals, &qh);
     let alpha_modifier: Option<WpAlphaModifierV1> = try_bind(&globals, &qh);
     let gamma_manager: Option<ZwlrGammaControlManagerV1> = try_bind(&globals, &qh);
-    let toplevel_manager: Option<ZwlrForeignToplevelManagerV1> = if config.skip_active {
-        try_bind(&globals, &qh)
-    } else {
-        None
-    };
+    let toplevel_manager: Option<ZwlrForeignToplevelManagerV1> = try_bind(&globals, &qh);
 
     // Create DimController
     let dim = DimController::new(
@@ -100,7 +97,6 @@ pub(crate) fn run(
         config
             .target_brightness
             .map(super::render::Brightness::as_f64),
-        config.skip_active,
     );
 
     let phase = if config.fade_duration.is_some() {
@@ -154,6 +150,9 @@ pub(crate) fn run(
     // Fade-in uses the event queue directly (flush + dispatch_pending)
     // to avoid reading new events that could disturb DimController state
     // while the animation is running.
+    //
+    // For spawn_with, all outputs fade in together (no skipping) so the
+    // callback's window launches behind fully opaque overlays.
     if let Some(duration) = app.config().fade_duration {
         run_fade_in(&mut app, &mut event_queue, duration)?;
     } else {
@@ -161,8 +160,16 @@ pub(crate) fn run(
         app.apply_updates(&updates);
     }
 
+    // For spawn_with: call the callback now that overlays are opaque,
+    // then enter WaitingForReveal to detect the new window.
+    if let Some(callback) = spawn_callback {
+        app.begin_waiting_for_reveal();
+        callback();
+    } else {
+        app.set_phase(AppPhase::Running);
+    }
+
     // Hand the event queue to calloop for steady-state dispatch
-    app.set_phase(AppPhase::Running);
     let mut event_loop: EventLoop<App> =
         EventLoop::try_new().map_err(|e| SpawnError::Setup(e.into()))?;
     WaylandSource::new(conn, event_queue)
@@ -223,14 +230,21 @@ fn run_steady_state(
     let animation_tick = Duration::from_millis(8);
     let idle_timeout = Duration::from_millis(100);
 
-    while app.phase() == AppPhase::Running {
+    while matches!(app.phase(), AppPhase::Running | AppPhase::WaitingForReveal) {
         if shutdown.load(Ordering::Acquire) {
             app.set_phase(AppPhase::ShuttingDown);
             break;
         }
 
+        if app.phase() == AppPhase::WaitingForReveal {
+            app.check_reveal();
+        }
+
         let timeout = if app.is_animating() {
             app.tick_transition();
+            animation_tick
+        } else if app.phase() == AppPhase::WaitingForReveal {
+            // Poll frequently while waiting for the new toplevel
             animation_tick
         } else {
             idle_timeout

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -17,7 +17,9 @@
 //! `zwlr_foreign_toplevel_manager_v1`: which output each toplevel is on and
 //! whether it has keyboard focus ([`ToplevelFocus`]). The `Done` event triggers
 //! [`App::refresh_active_output`] to start cross-fade transitions when focus
-//! moves between monitors.
+//! moves between monitors. During [`AppPhase::WaitingForReveal`] (after a
+//! `spawn_with` callback), `Done` events instead check for new fullscreen
+//! toplevels to trigger the reveal.
 //!
 //! Window movement (focused toplevel changing outputs mid-drag) snaps all
 //! overlays opaque immediately to prevent flash, then resumes normal
@@ -134,6 +136,11 @@ impl TrackedToplevel {
             ToplevelFocus::Active => self.output.as_ref(),
             ToplevelFocus::Inactive => None,
         }
+    }
+
+    /// The output this toplevel is currently on, regardless of focus.
+    pub fn output(&self) -> Option<&WlOutput> {
+        self.output.as_ref()
     }
 
     pub fn is_focused(&self) -> bool {
@@ -395,7 +402,11 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for App {
                 toplevel.update_focus(focus);
             }
             zwlr_foreign_toplevel_handle_v1::Event::Done => {
-                state.refresh_active_output();
+                if state.phase() == AppPhase::WaitingForReveal {
+                    state.check_reveal();
+                } else {
+                    state.refresh_active_output();
+                }
             }
             zwlr_foreign_toplevel_handle_v1::Event::Closed => {
                 state.remove_toplevel(proxy);

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,17 +12,26 @@ use crate::render::Color;
 use crate::render::Opacity;
 use crate::run::run;
 
+/// How the background thread was spawned — determines lifecycle phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpawnMode {
+    /// Standard spawn. Focus tracking is always on.
+    Standard,
+    /// Choreographed launch: fade in all outputs, run callback, reveal.
+    SpawnWith,
+}
+
 /// Resolved configuration passed to the background thread.
 ///
-/// Created from [`ZenWindowBuilder`] via the [`From`] impl. This is a plain
+/// Created from [`ZenWindowBuilder`] at spawn time. This is a plain
 /// data struct with no builder methods — all validation and defaults are
 /// handled by the builder.
 #[derive(Debug, Clone)]
 pub(crate) struct Config {
     /// Output names to never create surfaces on.
     pub(crate) skip_names: HashSet<String>,
-    /// Whether to leave the focused output undimmed.
-    pub(crate) skip_active: bool,
+    /// How this instance was spawned.
+    pub(crate) spawn_mode: SpawnMode,
     /// Layer-shell namespace for overlay surfaces.
     pub(crate) namespace: String,
     /// Delay before connecting to Wayland and creating surfaces.
@@ -40,7 +49,6 @@ pub(crate) struct Config {
 /// Builder for configuring which outputs to dim.
 pub struct ZenWindowBuilder {
     skip_names: HashSet<String>,
-    skip_active: bool,
     namespace: String,
     settle_delay: Option<Duration>,
     fade_duration: Option<Duration>,
@@ -54,7 +62,6 @@ impl ZenWindowBuilder {
     fn new() -> Self {
         Self {
             skip_names: HashSet::new(),
-            skip_active: false,
             namespace: "wl-zenwindow".into(),
             settle_delay: None,
             fade_duration: None,
@@ -68,17 +75,6 @@ impl ZenWindowBuilder {
     #[must_use]
     pub fn skip_output(mut self, name: impl Into<String>) -> Self {
         self.skip_names.insert(name.into());
-        self
-    }
-
-    /// Automatically skip the output that has the focused window.
-    ///
-    /// Uses `zwlr_foreign_toplevel_manager_v1` to detect which output
-    /// has the currently activated toplevel. Falls back to dimming all
-    /// outputs if the protocol is unavailable or no toplevel is focused.
-    #[must_use]
-    pub fn skip_active(mut self) -> Self {
-        self.skip_active = true;
         self
     }
 
@@ -172,21 +168,82 @@ impl ZenWindowBuilder {
     /// milliseconds). Returns a [`ZenWindow`] handle. Dropping it removes
     /// overlays and restores gamma.
     ///
+    /// Focus tracking is automatic: the focused output stays undimmed
+    /// while all other outputs are dimmed. If the compositor doesn't
+    /// support `zwlr_foreign_toplevel_manager_v1`, all outputs are dimmed.
+    ///
     /// # Errors
     ///
     /// Returns [`SpawnError`] if the Wayland connection fails, a required
     /// protocol is missing, setup fails after connecting, or the background
     /// thread cannot be created.
     pub fn spawn(self) -> Result<ZenWindow, SpawnError> {
+        self.spawn_inner(SpawnMode::Standard, None)
+    }
+
+    /// Spawn with a choreographed launch sequence.
+    ///
+    /// 1. Fades in ALL outputs to target opacity (everything goes dark)
+    /// 2. Calls the callback (your app launches behind the opaque overlay)
+    /// 3. Watches for the new window via toplevel protocol
+    /// 4. Once the window settles (fullscreen detected, or timeout), reveals
+    ///    the active output's overlay
+    ///
+    /// After the reveal, focus tracking is active — the focused output stays
+    /// undimmed while others remain dimmed.
+    ///
+    /// The callback runs on the background thread after the fade-in completes.
+    /// `FnOnce` since it's called exactly once. `Send + 'static` because it
+    /// crosses into the background thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpawnError`] if the Wayland connection fails, a required
+    /// protocol is missing, setup fails after connecting, or the background
+    /// thread cannot be created.
+    pub fn spawn_with<F>(self, f: F) -> Result<ZenWindow, SpawnError>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.spawn_inner(SpawnMode::SpawnWith, Some(Box::new(f)))
+    }
+
+    /// Spawn without blocking the calling thread.
+    ///
+    /// Returns immediately. Wayland setup and fade happen entirely
+    /// in the background. If setup fails, it fails silently.
+    ///
+    /// Returns a [`ZenWindow`] handle. Dropping it removes overlays.
+    #[must_use]
+    pub fn spawn_nonblocking(self) -> ZenWindow {
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let handle = std::thread::Builder::new()
+            .name("wl-zenwindow".into())
+            .spawn({
+                let config = self.to_config(SpawnMode::Standard);
+                let shutdown = Arc::clone(&shutdown);
+                move || run(&config, None, &shutdown, None)
+            })
+            .ok();
+
+        ZenWindow { handle, shutdown }
+    }
+
+    fn spawn_inner(
+        self,
+        spawn_mode: SpawnMode,
+        callback: Option<Box<dyn FnOnce() + Send + 'static>>,
+    ) -> Result<ZenWindow, SpawnError> {
         let (ready_tx, ready_rx) = mpsc::channel();
         let shutdown = Arc::new(AtomicBool::new(false));
 
         let handle = std::thread::Builder::new()
             .name("wl-zenwindow".into())
             .spawn({
-                let config = Config::from(&self);
+                let config = self.to_config(spawn_mode);
                 let shutdown = Arc::clone(&shutdown);
-                move || run(&config, Some(ready_tx), &shutdown)
+                move || run(&config, Some(ready_tx), &shutdown, callback)
             })
             .map_err(SpawnError::ThreadSpawn)?;
 
@@ -208,28 +265,6 @@ impl ZenWindowBuilder {
                 }
             }
         }
-    }
-
-    /// Spawn without blocking the calling thread.
-    ///
-    /// Returns immediately. Wayland setup and fade happen entirely
-    /// in the background. If setup fails, it fails silently.
-    ///
-    /// Returns a [`ZenWindow`] handle. Dropping it removes overlays.
-    #[must_use]
-    pub fn spawn_nonblocking(self) -> ZenWindow {
-        let shutdown = Arc::new(AtomicBool::new(false));
-
-        let handle = std::thread::Builder::new()
-            .name("wl-zenwindow".into())
-            .spawn({
-                let config = Config::from(&self);
-                let shutdown = Arc::clone(&shutdown);
-                move || run(&config, None, &shutdown)
-            })
-            .ok();
-
-        ZenWindow { handle, shutdown }
     }
 }
 
@@ -273,18 +308,17 @@ impl Drop for ZenWindow {
     }
 }
 
-/// Converts builder settings into internal config.
-impl From<&ZenWindowBuilder> for Config {
-    fn from(b: &ZenWindowBuilder) -> Self {
-        Self {
-            skip_names: b.skip_names.clone(),
-            skip_active: b.skip_active,
-            namespace: b.namespace.clone(),
-            settle_delay: b.settle_delay,
-            fade_duration: b.fade_duration,
-            target_opacity: b.opacity,
-            color: b.color,
-            target_brightness: b.brightness,
+impl ZenWindowBuilder {
+    fn to_config(&self, spawn_mode: SpawnMode) -> Config {
+        Config {
+            skip_names: self.skip_names.clone(),
+            spawn_mode,
+            namespace: self.namespace.clone(),
+            settle_delay: self.settle_delay,
+            fade_duration: self.fade_duration,
+            target_opacity: self.opacity,
+            color: self.color,
+            target_brightness: self.brightness,
         }
     }
 }
@@ -298,7 +332,6 @@ mod tests {
     fn builder_defaults() {
         let b = ZenWindowBuilder::new();
         assert!(b.skip_names.is_empty());
-        assert!(!b.skip_active);
         assert_eq!(b.namespace, "wl-zenwindow");
         assert!(b.settle_delay.is_none());
         assert!(b.fade_duration.is_none());
@@ -356,7 +389,6 @@ mod tests {
     #[test]
     fn builder_chaining() {
         let b = ZenWindow::builder()
-            .skip_active()
             .namespace("custom")
             .color([255, 0, 128])
             .opacity(0.5)
@@ -364,7 +396,6 @@ mod tests {
             .settle_delay(Duration::from_millis(200))
             .fade_in(Duration::from_millis(500));
 
-        assert!(b.skip_active);
         assert_eq!(b.namespace, "custom");
         assert_eq!(b.color, Color::new(255, 0, 128));
         assert!((b.opacity.as_f64() - 0.5).abs() < f64::EPSILON);
@@ -377,10 +408,9 @@ mod tests {
     }
 
     #[test]
-    fn config_from_builder_transfers_all_fields() {
+    fn config_transfers_all_fields() {
         let b = ZenWindow::builder()
             .skip_output("HDMI-1")
-            .skip_active()
             .namespace("test-ns")
             .settle_delay(Duration::from_millis(100))
             .fade_in(Duration::from_secs(1))
@@ -388,10 +418,10 @@ mod tests {
             .color([10, 20, 30])
             .brightness(0.6);
 
-        let config = Config::from(&b);
+        let config = b.to_config(SpawnMode::Standard);
 
         assert!(config.skip_names.contains("HDMI-1"));
-        assert!(config.skip_active);
+        assert_eq!(config.spawn_mode, SpawnMode::Standard);
         assert_eq!(config.namespace, "test-ns");
         assert_eq!(config.settle_delay, Some(Duration::from_millis(100)));
         assert_eq!(config.fade_duration, Some(Duration::from_secs(1)));
@@ -406,12 +436,19 @@ mod tests {
     }
 
     #[test]
-    fn config_from_builder_defaults() {
+    fn config_spawn_with_mode() {
         let b = ZenWindowBuilder::new();
-        let config = Config::from(&b);
+        let config = b.to_config(SpawnMode::SpawnWith);
+        assert_eq!(config.spawn_mode, SpawnMode::SpawnWith);
+    }
+
+    #[test]
+    fn config_defaults() {
+        let b = ZenWindowBuilder::new();
+        let config = b.to_config(SpawnMode::Standard);
 
         assert!(config.skip_names.is_empty());
-        assert!(!config.skip_active);
+        assert_eq!(config.spawn_mode, SpawnMode::Standard);
         assert_eq!(config.namespace, "wl-zenwindow");
         assert!(config.settle_delay.is_none());
         assert!(config.fade_duration.is_none());


### PR DESCRIPTION
Closes #30

## Changes

### API

**Removed `skip_active()`** — focus tracking is now always on. The focused output is automatically left undimmed. If the compositor lacks `zwlr_foreign_toplevel_manager_v1`, it degrades to dimming all outputs uniformly.

**Added `spawn_with()`** — choreographed launch sequence:

```rust
ZenWindow::builder()
    .fade_in(Duration::from_millis(300))
    .spawn_with(|| {
        Command::new("my-fullscreen-app").spawn().unwrap();
    })?;
```

Sequence:
1. Fade ALL outputs to target opacity (everything goes dark)
2. Call the callback (app launches behind opaque overlays)
3. Watch for new toplevel via `zwlr_foreign_toplevel_handle_v1`
4. Fullscreen detected → reveal immediately; timeout (5s) → reveal fallback
5. Enter steady-state with focus tracking active

### Internal

- `Config` replaces `skip_active: bool` with `spawn_mode: SpawnMode` enum (`Standard`/`SpawnWith`)
- `DimController` removes `skip_active` field (always-on), adds `reveal_output()` for the reveal transition
- `AppPhase::WaitingForReveal` phase with `RevealState` (toplevel snapshot + deadline)
- Toplevel manager is always bound (was previously gated on `skip_active`)
- `SpawnWith` mode skips marking outputs as active during setup so all outputs fade in together
- Spawn methods refactored to share `spawn_inner()`